### PR TITLE
Implement Gather operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ fn test_matmul_square_matrix() {
 |<a href="#Flatten">Flatten</a>|<a href="Changelog.md#Flatten-13">13</a>, <a href="Changelog.md#Flatten-11">11</a>, <a href="Changelog.md#Flatten-9">9</a>, <a href="Changelog.md#Flatten-1">1</a>|✅|
 |<a href="#Floor">Floor</a>|<a href="Changelog.md#Floor-13">13</a>, <a href="Changelog.md#Floor-6">6</a>, <a href="Changelog.md#Floor-1">1</a>|✅|
 |<a href="#GRU">GRU</a>|<a href="Changelog.md#GRU-14">14</a>, <a href="Changelog.md#GRU-7">7</a>, <a href="Changelog.md#GRU-3">3</a>, <a href="Changelog.md#GRU-1">1</a>|
-|<a href="#Gather">Gather</a>|<a href="Changelog.md#Gather-13">13</a>, <a href="Changelog.md#Gather-11">11</a>, <a href="Changelog.md#Gather-1">1</a>|
+|<a href="#Gather">Gather</a>|<a href="Changelog.md#Gather-13">13</a>, <a href="Changelog.md#Gather-11">11</a>, <a href="Changelog.md#Gather-1">1</a>|✅ (axis=0)|
 |<a href="#GatherElements">GatherElements</a>|<a href="Changelog.md#GatherElements-13">13</a>, <a href="Changelog.md#GatherElements-11">11</a>|
 |<a href="#GatherND">GatherND</a>|<a href="Changelog.md#GatherND-13">13</a>, <a href="Changelog.md#GatherND-12">12</a>, <a href="Changelog.md#GatherND-11">11</a>|
 |<a href="#Gemm">Gemm</a>|<a href="Changelog.md#Gemm-13">13</a>, <a href="Changelog.md#Gemm-11">11</a>, <a href="Changelog.md#Gemm-9">9</a>, <a href="Changelog.md#Gemm-7">7</a>, <a href="Changelog.md#Gemm-6">6</a>, <a href="Changelog.md#Gemm-1">1</a>|✅|

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -276,8 +276,8 @@ pub fn compile(
 
             let elements_per_index: u64 = i_dims[0][1..].iter().product();
             let scalar_type = agreed_type(&input_shapes[0..1], output_shapes)?;
-            let batch_type = MultiType::for_size(elements_per_index as usize, scalar_type);
-            let batch_size = batch_type.elements();
+            let chunk_type = MultiType::for_size(elements_per_index as usize, scalar_type);
+            let chunk_size = chunk_type.elements();
 
             // The X dimension represents the indexes
             let (x_threads, workgroup_size_x) = workgroup_size(
@@ -288,13 +288,13 @@ pub fn compile(
 
             // The Y dimension represents the elements to copy for each index
             let (y_threads, workgroup_size_y) = workgroup_size(
-                ceil(elements_per_index, batch_size as u64),
+                ceil(elements_per_index, chunk_size as u64),
                 MAX_COMPUTE_WORKGROUPS_PER_DIMENSION,
                 MAX_WORKGROUP_SIZE_Y,
             )?;
 
-            context.insert("batch_type", &batch_type.wgsl_type_name());
-            context.insert("batch_size", &batch_size);
+            context.insert("chunk_type", &chunk_type.wgsl_type_name());
+            context.insert("chunk_size", &chunk_size);
             context.insert("workgroup_size_x", &workgroup_size_x);
             context.insert("workgroup_size_y", &workgroup_size_y);
             context.insert("elements_per_index", &elements_per_index);

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -274,7 +274,7 @@ pub fn compile(
                 });
             }
 
-            let elements_per_index: u64 = i_dims[0][1..].iter().product();
+            let elements_per_index = input_chunks[0][0];
             let scalar_type = agreed_type(&input_shapes[0..1], output_shapes)?;
             let chunk_type = MultiType::for_size(elements_per_index as usize, scalar_type);
             let chunk_size = chunk_type.elements();
@@ -297,7 +297,6 @@ pub fn compile(
             context.insert("chunk_size", &chunk_size);
             context.insert("workgroup_size_x", &workgroup_size_x);
             context.insert("workgroup_size_y", &workgroup_size_y);
-            context.insert("elements_per_index", &elements_per_index);
 
             NodeTemplate {
                 scalar_type,

--- a/wonnx/templates/endomorphism/gather.wgsl
+++ b/wonnx/templates/endomorphism/gather.wgsl
@@ -4,23 +4,23 @@ struct Indices {
 	data: [[stride(4)]] array<i32>;
 };
 
-struct Batch {
-	data: [[stride({{ scalar_stride * batch_size }})]] array<{{ batch_type }}>;
+struct Chunk {
+	data: [[stride({{ scalar_stride * chunk_size }})]] array<{{ chunk_type }}>;
 };
 
 [[group(0), binding(0)]]
-var<storage, read> input_0: Batch; // data
+var<storage, read> input_0: Chunk; // data
 
 [[group(0), binding(1)]]
 var<storage, read> input_1: Indices; // indices
 
 [[group(0), binding(2)]]
-var<storage, write> output_0: Batch;
+var<storage, write> output_0: Chunk;
 
 [[stage(compute), workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})]]
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	let index_index = global_id.x; // Index of the index in the indices array that we are currently processing
-	let batch_index = global_id.y; // Batch of elements that we are copying for this index (batch size determined dynamically)
+	let chunk_index = global_id.y; // Chunk of elements that we are copying for this index (chunk size determined dynamically)
 
 	// Negative indexing is apparently allowed; see https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-38
 	var index = input_1.data[index_index];
@@ -28,5 +28,5 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		index = {{ i_shape[0][0] }} + index;
 	}
 
-	output_0.data[(index_index * u32({{ elements_per_index / batch_size }})) + batch_index] = input_0.data[index * i32({{ elements_per_index / batch_size }}) + i32(batch_index)];
+	output_0.data[(index_index * u32({{ elements_per_index / chunk_size }})) + chunk_index] = input_0.data[index * i32({{ elements_per_index / chunk_size }}) + i32(chunk_index)];
 }

--- a/wonnx/templates/endomorphism/gather.wgsl
+++ b/wonnx/templates/endomorphism/gather.wgsl
@@ -1,0 +1,32 @@
+{%- include "structs.wgsl" -%}
+
+struct Indices {
+	data: [[stride(4)]] array<i32>;
+};
+
+struct Batch {
+	data: [[stride({{ scalar_stride * batch_size }})]] array<{{ batch_type }}>;
+};
+
+[[group(0), binding(0)]]
+var<storage, read> input_0: Batch; // data
+
+[[group(0), binding(1)]]
+var<storage, read> input_1: Indices; // indices
+
+[[group(0), binding(2)]]
+var<storage, write> output_0: Batch;
+
+[[stage(compute), workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})]]
+fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+	let index_index = global_id.x; // Index of the index in the indices array that we are currently processing
+	let batch_index = global_id.y; // Batch of elements that we are copying for this index (batch size determined dynamically)
+
+	// Negative indexing is apparently allowed; see https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-38
+	var index = input_1.data[index_index];
+	if(index < 0) {
+		index = {{ i_shape[0][0] }} + index;
+	}
+
+	output_0.data[(index_index * u32({{ elements_per_index / batch_size }})) + batch_index] = input_0.data[index * i32({{ elements_per_index / batch_size }}) + i32(batch_index)];
+}

--- a/wonnx/templates/endomorphism/gather.wgsl
+++ b/wonnx/templates/endomorphism/gather.wgsl
@@ -21,7 +21,7 @@ var<storage, write> output_0: Chunk;
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	let index_index = global_id.x; // Index of the index in the indices array that we are currently processing
 	let chunk_index = global_id.y; // Chunk of elements that we are copying for this index (chunk size determined dynamically)
-	let index_stride = u32({{ i_chunks[0][0] / chunk_size }});
+	let index_stride = {{ i_chunks[0][0] / chunk_size }}u;
 
 	// Negative indexing is apparently allowed; see https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-38
 	var index = input_1.data[index_index];

--- a/wonnx/templates/endomorphism/gather.wgsl
+++ b/wonnx/templates/endomorphism/gather.wgsl
@@ -21,6 +21,7 @@ var<storage, write> output_0: Chunk;
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	let index_index = global_id.x; // Index of the index in the indices array that we are currently processing
 	let chunk_index = global_id.y; // Chunk of elements that we are copying for this index (chunk size determined dynamically)
+	let index_stride = u32({{ i_chunks[0][0] / chunk_size }});
 
 	// Negative indexing is apparently allowed; see https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-38
 	var index = input_1.data[index_index];
@@ -28,5 +29,5 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		index = {{ i_shape[0][0] }} + index;
 	}
 
-	output_0.data[(index_index * u32({{ elements_per_index / chunk_size }})) + chunk_index] = input_0.data[index * i32({{ elements_per_index / chunk_size }}) + i32(chunk_index)];
+	output_0.data[(index_index * index_stride) + chunk_index] = input_0.data[(index * i32(index_stride)) + i32(chunk_index)];
 }

--- a/wonnx/templates/structs.wgsl
+++ b/wonnx/templates/structs.wgsl
@@ -12,16 +12,17 @@ type Mat4x3 = mat4x3<{{ scalar_type }}>;
 
 struct Array {
 	data: [[stride({{ scalar_stride }})]] array<Scalar>;
-}; 
+};
 
 struct ArrayVector {
 	data: [[stride({{ vec4_stride }})]] array<Vec4>;
-}; 
+};
 
 struct ArrayMatrix {
 	data: [[stride({{ mat4x4_stride }})]] array<Mat4x4>;
-}; 
+};
 
 struct ArrayMatrix3 {
 	data: [[stride({{ mat3x3_stride }})]] array<Mat3x3>;
 };
+

--- a/wonnx/tests/gather.rs
+++ b/wonnx/tests/gather.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use wonnx::utils::{attribute, graph, model, node, tensor, InputTensor};
+mod common;
+
+fn assert_gather(
+    data: &[f32],
+    data_shape: &[i64],
+    indices: &[i32],
+    indices_shape: &[i64],
+    output: &[f32],
+    output_shape: &[i64],
+    axis: i64,
+) {
+    let mut input_data = HashMap::new();
+
+    input_data.insert("X".to_string(), InputTensor::F32(data));
+    input_data.insert("I".to_string(), InputTensor::I32(indices));
+
+    // Model: (X, I) -> Gather -> Y
+    let bn_model = model(graph(
+        vec![tensor("X", data_shape), tensor("I", indices_shape)],
+        vec![tensor("Y", output_shape)],
+        vec![],
+        vec![],
+        vec![node(
+            vec!["X", "I"],
+            vec!["Y"],
+            "myGather",
+            "Gather",
+            vec![attribute("axis", axis)],
+        )],
+    ));
+
+    let session =
+        pollster::block_on(wonnx::Session::from_model(bn_model)).expect("Session did not create");
+
+    let result = pollster::block_on(session.run(&input_data)).unwrap();
+    common::assert_eq_vector(result["Y"].as_slice(), output);
+}
+
+#[test]
+fn gather() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    // Very simple test case that just does simple selection from a 1D array
+    assert_gather(
+        &[1.0, 1.2, 2.3, 3.4, 4.5, 5.7],
+        &[6],
+        &[3, 2, 3, 1],
+        &[4],
+        &[3.4, 2.3, 3.4, 1.2],
+        &[4],
+        0,
+    );
+
+    // Very simple test case that just does simple selection from a 1D array, with negative indexing
+    assert_gather(
+        &[1.0, 1.2, 2.3, 3.4, 4.5, 5.7],
+        &[6],
+        &[-3, -2, -3, -1],
+        &[4],
+        &[3.4, 4.5, 3.4, 5.7],
+        &[4],
+        0,
+    );
+
+    // Test case for axis=0 from https://github.com/onnx/onnx/blob/main/docs/Operators.md#gather
+    assert_gather(
+        &[1.0, 1.2, 2.3, 3.4, 4.5, 5.7],
+        &[3, 2],
+        &[0, 1, 1, 2],
+        &[2, 2],
+        &[1.0, 1.2, 2.3, 3.4, 2.3, 3.4, 4.5, 5.7],
+        &[2, 2, 2],
+        0,
+    );
+
+    // Same as the above, but now with larger chunks to copy (so we test the shader's batching capability)
+    assert_gather(
+        &[1.0, 1.2, 2.3, 3.4, 4.5, 5.7, 1.0, 1.2, 2.3, 3.4, 4.5, 5.7],
+        &[3, 4],
+        &[0, 1, 1, 2],
+        &[2, 2],
+        &[
+            1.0, 1.2, 2.3, 3.4, 4.5, 5.7, 1.0, 1.2, 4.5, 5.7, 1.0, 1.2, 2.3, 3.4, 4.5, 5.7,
+        ],
+        &[2, 2, 4],
+        0,
+    );
+}


### PR DESCRIPTION
Implements the Gather operation, as used in e.g. BERTsquad. In a nutshell, this operator accepts a data tensor (typically f32) and an indexes tensor (typically i32), and produces a new tensor that has the elements at the specified indices from the data array. Using the 'axis' attribute it is possible to select indices from inner dimensions.

https://github.com/onnx/onnx/blob/main/docs/Operators.md#gather

Axis=0 case seems to work, need some more time to implement support for non-zero axis cases.