### PR TITLE
Process i64 data as i32 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,3 +384,6 @@ fn test_matmul_square_matrix() {
   parameters (i.e. axis). These inputs are only supported if they are supplied as initializer tensors (i.e. do not depend 
   on inputs and are not outputs of other ops), because wonnx pre-compiles all operations to shaders in advance (and must know
   these parameters up front).
+
+* Internally 64-bit integers are not supported (the reason is they are not supported in the current version of WGSL); 
+  inputs and initializers with 64-bit scalars are converted to 32-bit values (possibly overflowing).

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -216,6 +216,10 @@ fn agreed_type(
         }
     }
 
+    if let Some(ScalarType::I64) = data_type {
+        data_type = Some(ScalarType::I32);
+    }
+
     data_type.ok_or(CompileError::TypeUnderspecified)
 }
 

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -5,10 +5,10 @@ use tera::{Context, Tera};
 use thiserror::Error;
 
 /// The maximum number of threads that can be spawned in each dimension, according to the WebGPU specification. See
-// https://www.w3.org/TR/webgpu/#dom-supported-limits-maxcomputeworkgroupsperdimension
+/// <https://www.w3.org/TR/webgpu/#dom-supported-limits-maxcomputeworkgroupsperdimension>
 pub const MAX_COMPUTE_WORKGROUPS_PER_DIMENSION: u32 = 65535;
 
-/// The maximum workgroup size per dimension (see https://www.w3.org/TR/webgpu/#dom-supported-limits-maxcomputeworkgroupsizex)
+/// The maximum workgroup size per dimension (see <https://www.w3.org/TR/webgpu/#dom-supported-limits-maxcomputeworkgroupsizex>)
 pub const MAX_WORKGROUP_SIZE_X: u32 = 256;
 pub const MAX_WORKGROUP_SIZE_Y: u32 = 256;
 pub const MAX_WORKGROUP_SIZE_Z: u32 = 64;

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -607,7 +607,10 @@ impl GpuStep {
                     }
                     InputTensor::I64(int_input) => {
                         log::warn!("reading int64 input as int32 (int64 is not supported for calculation but can be used as input as long as values fit in int32)");
-                        let int32_input = int_input.iter().map(|x| *x as i32).collect();
+                        let int32_input = int_input
+                            .iter()
+                            .map(|i| i32::from_i64(*i).ok_or(GpuError::OutOfBoundsError))
+                            .collect::<Result<_, _>>()?;
                         queue.write_buffer(
                             input_buffer,
                             0,

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -316,6 +316,7 @@ impl GpuModel {
                         match &inference_inputs[input_name] {
                             InputTensor::F32(v) => v.to_vec(),
                             InputTensor::I32(v) => v.iter().map(|f| (*f) as f32).collect(),
+                            InputTensor::I64(v) => v.iter().map(|f| (*f) as f32).collect(),
                         }
                     }
                     InferenceOutput::Tensor(tensor) => {
@@ -336,44 +337,80 @@ trait TensorProtoExtra {
 impl TensorProtoExtra for TensorProto {
     /// Create a GPU buffer containing the data of this initializer
     fn buffer(&self, device: &wgpu::Device, readable: bool) -> Result<Buffer, GpuError> {
-        let input_shape = Shape::from(ScalarType::from_i32(self.get_data_type())?, self.get_dims());
+        let scalar_type = ScalarType::from_i32(self.get_data_type())?;
+        let input_shape = Shape::from(scalar_type, self.get_dims());
         log::info!(
-            "creating tensor buffer {} shape {}",
+            "creating buffer for tensor {} shape {}",
             self.get_name(),
             input_shape
         );
 
-        /// TODO read i64 tensors as i32 (and error on overflow)
-        let data = self.get_float_data();
-        let raw_data = if !data.is_empty() {
-            bytemuck::cast_slice(data)
-        } else {
-            self.get_raw_data()
-        };
-
-        let buffer_usage = match readable {
-            true => {
-                // On wgpu we can MAP_READ a buffer that is also used as STORAGE, but WebGPU (on at least Chrome)
-                // disallows this. Therefore we need to do an additional copy into a MAP_READ buffer when reading back a
-                // STORAGE buffer when on WebGPU.
-                if cfg!(target_arch = "wasm32") {
-                    BufferUsages::STORAGE | BufferUsages::COPY_SRC
-                } else {
-                    BufferUsages::STORAGE | BufferUsages::MAP_READ
-                }
+        match scalar_type {
+            ScalarType::F32 => {
+                let data = self.get_float_data();
+                buffer_with_bytes(
+                    device,
+                    readable,
+                    self.get_name(),
+                    if !data.is_empty() {
+                        bytemuck::cast_slice(data)
+                    } else {
+                        self.get_raw_data()
+                    },
+                )
             }
-            false => BufferUsages::STORAGE,
-        };
-
-        // Do not create buffers that are too small
-        Ok(if raw_data.len() < MINIMUM_BUFFER_SIZE_BYTES as _ {
-            let mut larger_raw_data = raw_data.to_vec();
-            larger_raw_data.resize(MINIMUM_BUFFER_SIZE_BYTES as _, 0);
-            resource::create_buffer_init(device, &larger_raw_data, self.get_name(), buffer_usage)
-        } else {
-            resource::create_buffer_init(device, raw_data, self.get_name(), buffer_usage)
-        })
+            ScalarType::I64 => {
+                // WGSL doesn't support 64 bit integers, so we load 64 bit tensors as 32 bit ints
+                log::warn!("initializers with int64 data type are not supported, converting into int32 initializer");
+                let ints: Vec<i32> = self.get_int64_data().iter().map(|x| *x as i32).collect();
+                let raw_data = bytemuck::cast_slice(&ints);
+                buffer_with_bytes(device, readable, self.get_name(), raw_data)
+            }
+            ScalarType::I32 => {
+                let data = self.get_int32_data();
+                buffer_with_bytes(
+                    device,
+                    readable,
+                    self.get_name(),
+                    if !data.is_empty() {
+                        bytemuck::cast_slice(data)
+                    } else {
+                        self.get_raw_data()
+                    },
+                )
+            }
+        }
     }
+}
+
+fn buffer_with_bytes(
+    device: &wgpu::Device,
+    readable: bool,
+    name: &str,
+    raw_data: &[u8],
+) -> Result<Buffer, GpuError> {
+    let buffer_usage = match readable {
+        true => {
+            // On wgpu we can MAP_READ a buffer that is also used as STORAGE, but WebGPU (on at least Chrome)
+            // disallows this. Therefore we need to do an additional copy into a MAP_READ buffer when reading back a
+            // STORAGE buffer when on WebGPU.
+            if cfg!(target_arch = "wasm32") {
+                BufferUsages::STORAGE | BufferUsages::COPY_SRC
+            } else {
+                BufferUsages::STORAGE | BufferUsages::MAP_READ
+            }
+        }
+        false => BufferUsages::STORAGE,
+    };
+
+    // Do not create buffers that are too small
+    Ok(if raw_data.len() < MINIMUM_BUFFER_SIZE_BYTES as _ {
+        let mut larger_raw_data = raw_data.to_vec();
+        larger_raw_data.resize(MINIMUM_BUFFER_SIZE_BYTES as _, 0);
+        resource::create_buffer_init(device, &larger_raw_data, name, buffer_usage)
+    } else {
+        resource::create_buffer_init(device, raw_data, name, buffer_usage)
+    })
 }
 
 impl<'model> OperatorDefinition<'model> {
@@ -552,6 +589,15 @@ impl GpuStep {
                             bytemuck::cast_slice(&resize(int_input.to_vec())),
                         );
                     }
+                    InputTensor::I64(int_input) => {
+                        log::warn!("reading int64 input as int32 (int64 is not supported for calculation but can be used as input as long as values fit in int32)");
+                        let int32_input = int_input.iter().map(|x| *x as i32).collect();
+                        queue.write_buffer(
+                            input_buffer,
+                            0,
+                            bytemuck::cast_slice(&resize(int32_input)),
+                        );
+                    }
                 }
 
                 Ok(())
@@ -614,7 +660,8 @@ impl GpuTensor {
                 result_ints.iter().map(|i| *i as f32).collect()
             }
             ScalarType::I64 => {
-                let result_ints: Vec<i64> =
+                log::warn!("reading int64 output as int32 because internally int64 scalars are not supported");
+                let result_ints: Vec<i32> =
                     bytemuck::cast_slice(&output_data)[..output_buffer_size].to_vec();
                 result_ints.iter().map(|i| *i as f32).collect()
             }

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -343,6 +343,7 @@ impl TensorProtoExtra for TensorProto {
             input_shape
         );
 
+        /// TODO read i64 tensors as i32 (and error on overflow)
         let data = self.get_float_data();
         let raw_data = if !data.is_empty() {
             bytemuck::cast_slice(data)

--- a/wonnx/src/resource.rs
+++ b/wonnx/src/resource.rs
@@ -52,7 +52,6 @@ pub fn resize<T: Clone + bytemuck::Pod>(mut array: Vec<T>) -> Vec<T> {
     if size < 4 && size != 0 {
         array.resize(size + 4 - size % 4, T::zeroed());
     }
-
     array
 }
 

--- a/wonnx/src/utils.rs
+++ b/wonnx/src/utils.rs
@@ -304,12 +304,19 @@ pub fn tensor_of_type(
     tensor
 }
 
-// Remove dimensions
 pub fn initializer(name: &str, data: Vec<f32>) -> onnx::TensorProto {
     let mut initializer = crate::onnx::TensorProto::new();
     initializer.set_name(name.to_string());
     initializer.set_data_type(TensorProto_DataType::FLOAT.value());
     initializer.set_float_data(data);
+    initializer
+}
+
+pub fn initializer_int64(name: &str, data: Vec<i64>) -> onnx::TensorProto {
+    let mut initializer = crate::onnx::TensorProto::new();
+    initializer.set_name(name.to_string());
+    initializer.set_data_type(TensorProto_DataType::INT64.value());
+    initializer.set_int64_data(data);
     initializer
 }
 

--- a/wonnx/src/utils.rs
+++ b/wonnx/src/utils.rs
@@ -308,7 +308,7 @@ pub fn tensor_of_type(
 pub fn initializer(name: &str, data: Vec<f32>) -> onnx::TensorProto {
     let mut initializer = crate::onnx::TensorProto::new();
     initializer.set_name(name.to_string());
-    initializer.set_data_type(1); // FLOAT
+    initializer.set_data_type(TensorProto_DataType::FLOAT.value());
     initializer.set_float_data(data);
     initializer
 }

--- a/wonnx/src/utils.rs
+++ b/wonnx/src/utils.rs
@@ -65,6 +65,7 @@ impl Shape {
 pub enum InputTensor<'a> {
     F32(Cow<'a, [f32]>),
     I32(Cow<'a, [i32]>),
+    I64(Cow<'a, [i64]>),
 }
 
 impl<'a> From<&'a [f32]> for InputTensor<'a> {
@@ -76,6 +77,12 @@ impl<'a> From<&'a [f32]> for InputTensor<'a> {
 impl<'a> From<&'a [i32]> for InputTensor<'a> {
     fn from(a: &'a [i32]) -> Self {
         InputTensor::I32(Cow::Borrowed(a))
+    }
+}
+
+impl<'a> From<&'a [i64]> for InputTensor<'a> {
+    fn from(a: &'a [i64]) -> Self {
+        InputTensor::I64(Cow::Borrowed(a))
     }
 }
 

--- a/wonnx/tests/reduce.rs
+++ b/wonnx/tests/reduce.rs
@@ -1,8 +1,7 @@
-use protobuf::ProtobufEnum;
 use std::collections::HashMap;
 use wonnx::{
-    onnx::{AttributeProto, TensorProto, TensorProto_DataType},
-    utils::{attribute, graph, model, node, tensor},
+    onnx::AttributeProto,
+    utils::{attribute, graph, initializer_int64, model, node, tensor},
 };
 mod common;
 
@@ -235,14 +234,6 @@ fn reduce() {
     );
 }
 
-pub fn initializer_int(name: &str, data: Vec<i64>) -> TensorProto {
-    let mut initializer = TensorProto::new();
-    initializer.set_name(name.to_string());
-    initializer.set_data_type(TensorProto_DataType::INT64.value()); // FLOAT
-    initializer.set_int64_data(data);
-    initializer
-}
-
 // Separate test for the case where ReduceSum takes an axes input
 // Test case adapted from https://github.com/onnx/onnx/blob/94e2f64551ded652df53a7e9111031e8aabddaee/onnx/backend/test/case/node/reducesum.py#L92
 #[test]
@@ -270,7 +261,7 @@ fn test_reduce_sum_with_axes_as_input() {
         vec![tensor("X", &[3, 2, 2])],
         vec![tensor("Y", &[3, 2])],
         vec![],
-        vec![initializer_int("A", vec![-2])],
+        vec![initializer_int64("A", vec![-2])],
         vec![node(
             vec!["X", "A"],
             vec!["Y"],


### PR DESCRIPTION
WGSL does not appear to support 64-bit integers, so the best we can do (apart from building all sorts of complicated 64-bit logic based on 32 bit ints) is to use i32 instead (this also means: load i64 tensors as i32) and hope for the best (and wait for WGSL to start supporting 64 bit ints).

In practice it appears models use i64 but do not need the full range (i.e. in one of the ONNX files for BERTSQuAD, the input tokens are i64 tensors, but these values would also fit in i32).

Still need to implement the 64-to-32 conversion when loading tensors.