### PR TITLE
Feature/test specific op

### DIFF
--- a/.github/test_onnx_backend.sh
+++ b/.github/test_onnx_backend.sh
@@ -3,6 +3,7 @@ rustup override set nightly-2022-01-01
 export RUSTFLAGS='-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+popcnt'
 python3 -m venv .env
 source .env/bin/activate
+pip install --upgrade pip
 pip install maturin
 pip install -r requirements.txt
 maturin develop

--- a/.github/test_onnx_backend.sh
+++ b/.github/test_onnx_backend.sh
@@ -1,0 +1,9 @@
+cd wonnx-py
+rustup override set nightly-2022-01-01
+export RUSTFLAGS='-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+popcnt'
+python3 -m venv .env
+source .env/bin/activate
+pip install maturin
+pip install -r requirements.txt
+maturin develop
+pytest tests/test_onnx_backend.py

--- a/.github/workflows/check-onnx-backend.yaml
+++ b/.github/workflows/check-onnx-backend.yaml
@@ -11,8 +11,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run Tests
-        uses: docker://konstin2/maturin:latest
+      - uses: actions/setup-python@v2
         with:
-          entrypoint: /bin/bash
-          args: .github/test_onnx_backend.sh
+          python-version: 3.9
+      - name: install llvmpipe and lavapipe
+        run: |
+          sudo apt-get update -y -qq
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+          sudo apt-get update
+          sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: test
+        run: |
+          cd wonnx-py
+          rustup override set nightly-2022-01-01
+          export RUSTFLAGS='-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+popcnt'
+          python3 -m venv .env
+          source .env/bin/activate
+          pip install --upgrade pip
+          pip install maturin
+          pip install -r requirements.txt
+          maturin develop
+          WGPU_BACKEND=vulkan pytest tests/test_onnx_backend.py

--- a/.github/workflows/check-onnx-backend.yaml
+++ b/.github/workflows/check-onnx-backend.yaml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   build_manylinux:
-    name: Create Release manylinux
+    name: Build and Test ONNX Backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Publish wheel
+      - name: Run Tests
         uses: docker://konstin2/maturin:latest
         with:
           entrypoint: /bin/bash

--- a/.github/workflows/check-onnx-backend.yaml
+++ b/.github/workflows/check-onnx-backend.yaml
@@ -1,0 +1,18 @@
+name: Check ONNX Backend using Python automated test
+
+on:
+  push:
+    branches: [master, staging]
+  pull_request:
+
+jobs:
+  build_manylinux:
+    name: Create Release manylinux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish wheel
+        uses: docker://konstin2/maturin:latest
+        with:
+          entrypoint: /bin/bash
+          args: .github/test_onnx_backend.sh

--- a/wonnx-py/README.md
+++ b/wonnx-py/README.md
@@ -12,4 +12,17 @@ python3 -m venv .env
 source .env/bin/activate
 pip install maturin
 maturin develop
+pip install -r requirements.txt
 ````
+
+## Testing
+
+To test a specific operator, you can use the following command:
+```bash
+OP_TESTED=reduce pytest tests/test_specific_op.py
+```
+
+To test the current set of fully tested op:
+```bash
+python tests/test_onnx_backend.py
+```

--- a/wonnx-py/README.md
+++ b/wonnx-py/README.md
@@ -6,23 +6,32 @@ This crate allows using WONNX from Python.
 
 To build the Python module for development:
 
-````sh
+````bash
 cd wonnx-py
 python3 -m venv .env
 source .env/bin/activate
 pip install maturin
 maturin develop
-pip install -r requirements.txt
 ````
 
 ## Testing
 
+For testing, additional dependencies are required. First, ensure you have the protobuf compiler (`protoc`) installed and
+in your PATH (on macOS, you can use `brew install protobuf` and possibly `brew link protobuf` to install it). Nextl, install
+Python dependencies:
+
+````bash
+pip install -r requirements.txt
+````
+
 To test a specific operator, you can use the following command:
+
 ```bash
 OP_TESTED=reduce pytest tests/test_specific_op.py
 ```
 
 To test the current set of fully tested op:
+
 ```bash
 python tests/test_onnx_backend.py
 ```

--- a/wonnx-py/pyproject.toml
+++ b/wonnx-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "wonnx"
 dependencies = [
   "typing_extensions >= 4.0.0; python_version < '3.10'",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 
 [tool.isort]
 profile = "black"

--- a/wonnx-py/requirements.txt
+++ b/wonnx-py/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 onnx
 torchvision
+tabulate

--- a/wonnx-py/requirements.txt
+++ b/wonnx-py/requirements.txt
@@ -1,2 +1,3 @@
 pytest
+onnx
 torchvision

--- a/wonnx-py/tests/test_onnx_backend.py
+++ b/wonnx-py/tests/test_onnx_backend.py
@@ -156,6 +156,19 @@ backend_test.include(f"test_exp_[a-z,_]*")
 backend_test.include(f"test_floor_[a-z,_]*")
 backend_test.include(f"test_leakyrelu_[a-z,_]*")
 
+# Disable tests for ReduceSum because ReduceSum accepts the 'axes' list as input instead of as an attribute, and the test
+# case sets the 'axes' input dynamically, which we don't support (yet?).
+# backend_test.include(f"test_reduce_sum_[a-z,_]*")
+backend_test.include(f"test_reduce_mean_[a-z,_]*")
+backend_test.include(f"test_reduce_l1_[a-z,_]*")
+backend_test.include(f"test_reduce_l2_[a-z,_]*")
+backend_test.include(f"test_reduce_min_[a-z,_]*")
+backend_test.include(f"test_reduce_prod_[a-z,_]*")
+backend_test.include(f"test_reduce_sum_square_[a-z,_]*")
+backend_test.include(f"test_reduce_max_[a-z,_]*")
+backend_test.include(f"test_reduce_log_sum_[a-z,_]*")
+backend_test.include(f"test_reduce_log_sum_exp_[a-z,_]*")
+
 
 globals().update(backend_test.enable_report().test_cases)
 

--- a/wonnx-py/tests/test_specific_op.py
+++ b/wonnx-py/tests/test_specific_op.py
@@ -1,149 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import itertools
-import os
-import platform
-import unittest
-import onnx.backend.base
 import onnx.backend.test
 
-from onnx.backend.base import BackendRep, Device, DeviceType, namedtupledict
-from onnx.backend.test.runner import BackendIsNotSupposedToImplementIt
-import onnx.shape_inference
-import onnx.version_converter
-from typing import NamedTuple, Optional, Text, Any, Tuple, Sequence
-from onnx import NodeProto, ModelProto, TensorProto
-import numpy  # type: ignore
-
-# The following just executes the fake backend through the backend test
-# infrastructure. Since we don't have full reference implementation of all ops
-# in ONNX repo, it's impossible to produce the proper results. However, we can
-# run 'checker' (that's what base Backend class does) to verify that all tests
-# fed are actually well-formed ONNX models.
-#
-# If everything is fine, all the tests would be marked as "skipped".
-#
-# We don't enable report in this test because the report collection logic itself
-# fails when models are mal-formed.
-
-
-# This is a pytest magic variable to load extra plugins
 pytest_plugins = ("onnx.backend.test.report",)
 
+import os
 import wonnx
-import numpy as np
+import unittest
+
+from test_onnx_backend import DummyBackend
 
 OP_TESTED = os.environ["OP_TESTED"]
-
-
-class DummyRep(BackendRep):
-    def __init__(self, inputs, outputs, outputs_shape, model):
-        self.inputs = inputs
-        self.outputs = outputs
-        self.outputs_shape = outputs_shape
-        self.session = wonnx.PySession.from_bytes(onnx._serialize(model))
-        self.rtol = 1
-        pass
-
-    def run(self, inputs, rtol=1.0, **kwargs):
-
-        dicts = {}
-        for k, v in zip(self.inputs, inputs):
-            if isinstance(v, np.ndarray):
-                dicts[k] = v.flatten()
-            else:
-                tmp_v = np.array(v)
-                np.reshape(tmp_v, self.outputs_shape[k])
-                dicts[k] = tmp_v
-
-        results = self.session.run(dicts)
-
-        outputs = []
-        for item in results.items():
-            tmp_v = np.array(item[1])
-            tmp_v = np.reshape(tmp_v, self.outputs_shape[item[0]])
-            tmp_v = tmp_v.astype("float32")
-            outputs.append(tmp_v)
-        return outputs
-
-
-class DummyBackend(onnx.backend.base.Backend):
-    @classmethod
-    def prepare(
-        cls,
-        model,  # type: ModelProto
-        inputs,
-        device="CPU",  # type: Text
-        **kwargs,  # type: Any
-    ):  # type: (...) -> Optional[onnx.backend.base.BackendRep]
-        super(DummyBackend, cls).prepare(model, device, **kwargs)
-
-        # test shape inference
-        model = onnx.shape_inference.infer_shapes(model)
-        inputs = [input.name for input in model.graph.input]
-        outputs = [output.name for output in model.graph.output]
-
-        outputs_shape = {}
-        for output in model.graph.output:
-            outputs_shape[output.name] = [
-                shape.dim_value for shape in output.type.tensor_type.shape.dim
-            ]
-
-        if do_enforce_test_coverage_safelist(model):
-            for node in model.graph.node:
-                for i, output in enumerate(node.output):
-                    if node.op_type == "Dropout" and i != 0:
-                        continue
-                    assert output in value_infos
-                    tt = value_infos[output].type.tensor_type
-                    assert tt.elem_type != TensorProto.UNDEFINED
-                    for dim in tt.shape.dim:
-                        assert dim.WhichOneof("value") == "dim_value"
-
-        return DummyRep(
-            inputs=inputs,
-            outputs=outputs,
-            model=model,
-            outputs_shape=outputs_shape,
-        )
-
-    @classmethod
-    def supports_device(cls, device):  # type: (Text) -> bool
-        d = Device(device)
-        if d.type == DeviceType.CPU:
-            return True
-        return False
-
-
-test_coverage_safelist = set(
-    [
-        "bvlc_alexnet",
-        "densenet121",
-        "inception_v1",
-        "inception_v2",
-        "resnet50",
-        "shufflenet",
-        "SingleRelu",
-        "squeezenet_old",
-        "vgg19",
-        "zfnet",
-    ]
-)
-
-
-def do_enforce_test_coverage_safelist(model):  # type: (ModelProto) -> bool
-    if model.graph.name not in test_coverage_safelist:
-        return False
-    for node in model.graph.node:
-        if node.op_type in set(["RNN", "LSTM", "GRU"]):
-            return False
-    return True
-
 
 backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__)
 

--- a/wonnx-py/tests/test_specific_op.py
+++ b/wonnx-py/tests/test_specific_op.py
@@ -38,6 +38,8 @@ pytest_plugins = ("onnx.backend.test.report",)
 import wonnx
 import numpy as np
 
+OP_TESTED = os.environ["OP_TESTED"]
+
 
 class DummyRep(BackendRep):
     def __init__(self, inputs, outputs, outputs_shape, model):
@@ -145,17 +147,7 @@ def do_enforce_test_coverage_safelist(model):  # type: (ModelProto) -> bool
 
 backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__)
 
-backend_test.include(f"test_relu_[a-z,_]*")
-backend_test.include(f"test_conv_[a-z,_]*")
-backend_test.include(f"test_abs_[a-z,_]*")
-backend_test.include(f"test_acos_[a-z,_]*")
-backend_test.include(f"test_atan_[a-z,_]*")
-backend_test.include(f"test_ceil_[a-z,_]*")
-backend_test.include(f"test_cos_[a-z,_]*")
-backend_test.include(f"test_exp_[a-z,_]*")
-backend_test.include(f"test_floor_[a-z,_]*")
-backend_test.include(f"test_leakyrelu_[a-z,_]*")
-
+backend_test.include(f"test_{OP_TESTED}_[a-z,_]*")
 
 globals().update(backend_test.enable_report().test_cases)
 

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -558,8 +558,13 @@ pub fn compile(
                 ),
             }
         }
-        "Relu" | "Sigmoid" | "Softsign" | "Softplus" | "Clip" | "Celu" | "Elu" | "LeakyRelu" => {
-            let alpha = get_attribute("alpha", Some(1.0), node)?;
+        op @ ("Relu" | "Sigmoid" | "Softsign" | "Softplus" | "Clip" | "Celu" | "Elu"
+        | "LeakyRelu") => {
+            let alpha = if op == "LeakyRelu" {
+                get_attribute("alpha", Some(0.01), node)?
+            } else {
+                get_attribute("alpha", Some(1.0), node)?
+            };
             context.insert("alpha", &alpha);
 
             let (x_threads, workgroup_size_x) = workgroup_size(

--- a/wonnx/templates/snippets/activation_vec.wgsl
+++ b/wonnx/templates/snippets/activation_vec.wgsl
@@ -45,7 +45,7 @@
 	{{ activation_output }} = input_vec * tanh(log(Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)) + exp(input_vec)));
 
 {%- elif activation_type == "LeakyRelu" -%}
-	{{ activation_output }} = max({{ alpha }} * {{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)));
+	{{ activation_output }} = max(Scalar({{ alpha }}) * {{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)));
 
 {%- elif activation_output != activation_input -%}
 	{{ activation_output }} = {{ activation_input }};

--- a/wonnx/templates/snippets/activation_vec.wgsl
+++ b/wonnx/templates/snippets/activation_vec.wgsl
@@ -45,7 +45,8 @@
 	{{ activation_output }} = input_vec * tanh(log(Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)) + exp(input_vec)));
 
 {%- elif activation_type == "LeakyRelu" -%}
-	{{ activation_output }} = max(Scalar({{ alpha }}) * {{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)));
+	{{ activation_output }} = max({{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)))
+	                         + min(Scalar({{ alpha }}) * {{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)));
 
 {%- elif activation_output != activation_input -%}
 	{{ activation_output }} = {{ activation_input }};


### PR DESCRIPTION
Generating automated test on the onnx backend for python for specific op. I have cleaned up the backend test a bit to only feature tests for op that is currently fully passing. There are some Ops that are not fully working.

## To install
```bash
cd wonnx-py
python3 -m venv .env
source .env/bin/activate
pip install maturin
pip install -r requirements.txt
maturin develop
```


## To use
```bash
cd wonnx-py
OP_TESTED=reduce pytest tests/test_specific_op.py
```