### PR TITLE
Feature/integer outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ fn test_matmul_square_matrix() {
 
     // Note: it is better to use a method that compares floats with a tolerance to account for differences
     // between implementations; see `wonnx/tests/common/mod.rs` for an example.
-    assert_eq!(result["C"].unwrap_f32_slice(), sum.as_slice().unwrap());
+    assert_eq!((&result["C"]).try_into().unwrap(),sum.as_slice().unwrap());
 }
 ```
 > Check out tera documentation for other templating operation: https://tera.netlify.app/docs/

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ fn test_matmul_square_matrix() {
 
     let result = pollster::block_on(session.run(input_data)).unwrap();
 
-    assert_eq!(result["C"].as_slice(), sum.as_slice().unwrap());
+    // Note: it is better to use a method that compares floats with a tolerance to account for differences
+    // between implementations; see `wonnx/tests/common/mod.rs` for an example.
+    assert_eq!(result["C"].unwrap_f32_slice(), sum.as_slice().unwrap());
 }
 ```
 > Check out tera documentation for other templating operation: https://tera.netlify.app/docs/

--- a/wonnx-cli/src/cpu.rs
+++ b/wonnx-cli/src/cpu.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use crate::{InferOptions, Inferer, NNXError};
 use async_trait::async_trait;
 use tract_onnx::prelude::*;
-use wonnx::{onnx::ModelProto, utils::Shape};
+use wonnx::{
+    onnx::ModelProto,
+    utils::{OutputTensor, Shape},
+};
 
 type RunnableOnnxModel =
     SimplePlan<TypedFact, Box<dyn TypedOp>, Graph<TypedFact, Box<dyn TypedOp>>>;
@@ -62,7 +65,7 @@ impl Inferer for CPUInferer {
         infer_opt: &InferOptions,
         inputs: &HashMap<String, crate::Tensor>,
         model: &ModelProto,
-    ) -> Result<Vec<f32>, NNXError> {
+    ) -> Result<OutputTensor, NNXError> {
         let mut cpu_inputs: HashMap<usize, tract_onnx::prelude::Tensor> = HashMap::new();
 
         for (input_name, input_tensor) in inputs {
@@ -119,6 +122,6 @@ impl Inferer for CPUInferer {
         };
 
         let av = result_vector.to_array_view()?;
-        Ok(av.as_slice().unwrap().to_vec())
+        Ok(OutputTensor::F32(av.as_slice().unwrap().to_vec()))
     }
 }

--- a/wonnx-cli/src/gpu.rs
+++ b/wonnx-cli/src/gpu.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use wonnx::onnx::ModelProto;
 
 use async_trait::async_trait;
+use wonnx::utils::OutputTensor;
 
 use crate::types::InferOptions;
 use crate::types::Inferer;
@@ -27,7 +28,7 @@ impl Inferer for GPUInferer {
         infer_opt: &InferOptions,
         inputs: &HashMap<String, crate::Tensor>,
         _model: &ModelProto,
-    ) -> Result<Vec<f32>, NNXError> {
+    ) -> Result<OutputTensor, NNXError> {
         let input_refs = inputs
             .iter()
             .map(|(k, v)| (k.clone(), v.input_tensor()))

--- a/wonnx-cli/src/main.rs
+++ b/wonnx-cli/src/main.rs
@@ -159,10 +159,10 @@ async fn run() -> Result<(), NNXError> {
                         let _ = gpu_backend.infer(&infer_opt, &inputs, &model).await?;
                     }
                 }
-                let gpu_output = gpu_backend
+                let gpu_output: Vec<f32> = gpu_backend
                     .infer(&infer_opt, &inputs, &model)
                     .await?
-                    .as_f32()?;
+                    .try_into()?;
                 let gpu_time = gpu_start.elapsed();
                 log::info!("gpu time: {}ms", gpu_time.as_millis());
                 drop(gpu_backend);
@@ -176,10 +176,10 @@ async fn run() -> Result<(), NNXError> {
                         let _ = cpu_backend.infer(&infer_opt, &inputs, &model).await?;
                     }
                 }
-                let cpu_output = cpu_backend
+                let cpu_output: Vec<f32> = cpu_backend
                     .infer(&infer_opt, &inputs, &model)
                     .await?
-                    .as_f32()?;
+                    .try_into()?;
                 let cpu_time = cpu_start.elapsed();
                 log::info!(
                     "cpu time: {}ms ({:.2}x gpu time)",

--- a/wonnx-cli/src/main.rs
+++ b/wonnx-cli/src/main.rs
@@ -271,11 +271,8 @@ async fn run() -> Result<(), NNXError> {
                 Some(labels_path) => {
                     let labels = get_lines(&labels_path);
 
-                    let mut probabilities = output
-                        .unwrap_f32_slice()
-                        .iter()
-                        .enumerate()
-                        .collect::<Vec<_>>();
+                    let output_slice: Vec<f32> = output.try_into().unwrap();
+                    let mut probabilities = output_slice.iter().enumerate().collect::<Vec<_>>();
                     probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(a.1).unwrap());
 
                     let top = infer_opt.top.unwrap_or(10);

--- a/wonnx-cli/src/main.rs
+++ b/wonnx-cli/src/main.rs
@@ -159,7 +159,10 @@ async fn run() -> Result<(), NNXError> {
                         let _ = gpu_backend.infer(&infer_opt, &inputs, &model).await?;
                     }
                 }
-                let gpu_output = gpu_backend.infer(&infer_opt, &inputs, &model).await?;
+                let gpu_output = gpu_backend
+                    .infer(&infer_opt, &inputs, &model)
+                    .await?
+                    .as_f32()?;
                 let gpu_time = gpu_start.elapsed();
                 log::info!("gpu time: {}ms", gpu_time.as_millis());
                 drop(gpu_backend);
@@ -173,7 +176,10 @@ async fn run() -> Result<(), NNXError> {
                         let _ = cpu_backend.infer(&infer_opt, &inputs, &model).await?;
                     }
                 }
-                let cpu_output = cpu_backend.infer(&infer_opt, &inputs, &model).await?;
+                let cpu_output = cpu_backend
+                    .infer(&infer_opt, &inputs, &model)
+                    .await?
+                    .as_f32()?;
                 let cpu_time = cpu_start.elapsed();
                 log::info!(
                     "cpu time: {}ms ({:.2}x gpu time)",
@@ -265,7 +271,11 @@ async fn run() -> Result<(), NNXError> {
                 Some(labels_path) => {
                     let labels = get_lines(&labels_path);
 
-                    let mut probabilities = output.iter().enumerate().collect::<Vec<_>>();
+                    let mut probabilities = output
+                        .unwrap_f32_slice()
+                        .iter()
+                        .enumerate()
+                        .collect::<Vec<_>>();
                     probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(a.1).unwrap());
 
                     let top = infer_opt.top.unwrap_or(10);

--- a/wonnx-cli/src/types.rs
+++ b/wonnx-cli/src/types.rs
@@ -1,7 +1,11 @@
 use std::{collections::HashMap, num::ParseFloatError, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 use thiserror::Error;
-use wonnx::{onnx::ModelProto, SessionError, WonnxError};
+use wonnx::{
+    onnx::ModelProto,
+    utils::{OutputTensor, TensorConversionError},
+    SessionError, WonnxError,
+};
 use wonnx_preprocessing::{text::PreprocessingError, Tensor};
 
 #[cfg(feature = "cpu")]
@@ -54,6 +58,9 @@ pub enum NNXError {
 
     #[error("invalid number: {0}")]
     InvalidNumber(ParseFloatError),
+
+    #[error("tensor error: {0}")]
+    TensorConversionError(#[from] TensorConversionError),
 }
 
 impl FromStr for Backend {
@@ -181,5 +188,5 @@ pub trait Inferer {
         infer_opt: &InferOptions,
         inputs: &HashMap<String, Tensor>,
         model: &ModelProto,
-    ) -> Result<Vec<f32>, NNXError>;
+    ) -> Result<OutputTensor, NNXError>;
 }

--- a/wonnx-wasm/src/lib.rs
+++ b/wonnx-wasm/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_console_logger::DEFAULT_LOGGER;
 use wasm_bindgen_futures::future_to_promise;
-use wonnx::utils::InputTensor;
+use wonnx::utils::{InputTensor, OutputTensor};
 
 #[wasm_bindgen(start)]
 pub fn main() {
@@ -88,5 +88,14 @@ impl Session {
             drop(input_copy);
             Ok(JsValue::from_serde(&result).unwrap())
         })
+    }
+}
+
+/// Convert an OutputTensor to a JsValue (we cannot implement Into<JsValue> for OutputTensor here)
+pub fn tensor_to_js_value(tensor: OutputTensor) -> JsValue {
+    match tensor {
+        OutputTensor::F32(fs) => JsValue::from_serde(&fs).unwrap(),
+        OutputTensor::I32(ints) => JsValue::from_serde(&ints).unwrap(),
+        OutputTensor::I64(ints) => JsValue::from_serde(&ints).unwrap(),
     }
 }

--- a/wonnx/Cargo.toml
+++ b/wonnx/Cargo.toml
@@ -27,7 +27,7 @@ tera = { version = "1.15.0", default-features = false }
 lazy_static = "1.4.0"
 thiserror = "^1.0.0"
 serde_derive = "1.0.133"
-serde = "1.0.133"
+serde = {version = "1.0.133", features = ["derive"] }
 num = "0.4.0"
 
 [dev-dependencies]

--- a/wonnx/examples/mnist.rs
+++ b/wonnx/examples/mnist.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryInto;
 
 use image::{imageops::FilterType, ImageBuffer, Pixel, Rgb};
 use std::path::Path;
@@ -9,7 +10,7 @@ use wonnx::utils::OutputTensor;
 async fn run() {
     let probabilities = execute_gpu().await.unwrap();
     let (_, probabilities) = probabilities.into_iter().next().unwrap();
-    let probabilities = probabilities.as_f32().unwrap();
+    let probabilities: Vec<f32> = probabilities.try_into().unwrap();
     println!("steps: {:#?}", probabilities);
     println!("steps: {:#?}", probabilities.len());
 

--- a/wonnx/examples/mnist.rs
+++ b/wonnx/examples/mnist.rs
@@ -3,11 +3,13 @@ use std::collections::HashMap;
 use image::{imageops::FilterType, ImageBuffer, Pixel, Rgb};
 use std::path::Path;
 use std::time::Instant;
+use wonnx::utils::OutputTensor;
 
 // Args Management
 async fn run() {
     let probabilities = execute_gpu().await.unwrap();
-    let (_, probabilities) = probabilities.iter().next().unwrap();
+    let (_, probabilities) = probabilities.into_iter().next().unwrap();
+    let probabilities = probabilities.as_f32().unwrap();
     println!("steps: {:#?}", probabilities);
     println!("steps: {:#?}", probabilities.len());
 
@@ -19,7 +21,7 @@ async fn run() {
 }
 
 // Hardware management
-async fn execute_gpu() -> Option<HashMap<String, Vec<f32>>> {
+async fn execute_gpu() -> Option<HashMap<String, OutputTensor>> {
     let mut input_data = HashMap::new();
 
     let image = load_image();

--- a/wonnx/examples/simple_graph.rs
+++ b/wonnx/examples/simple_graph.rs
@@ -1,20 +1,23 @@
 use std::collections::HashMap;
 
 use wonnx::{
-    utils::{attribute, graph, initializer, model, node, tensor},
+    utils::{attribute, graph, initializer, model, node, tensor, OutputTensor},
     SessionError, WonnxError,
 };
 
 async fn run() -> Result<(), WonnxError> {
-    let result = &execute_gpu().await?;
-    let (_, result) = result.iter().next().unwrap();
+    let result = execute_gpu().await?;
+    let result = result.into_iter().next().unwrap().1;
 
-    assert_eq!(result, &[54., 63., 72., 99., 108., 117., 144., 153., 162.]);
+    assert_eq!(
+        result,
+        OutputTensor::F32(vec![54., 63., 72., 99., 108., 117., 144., 153., 162.])
+    );
     Ok(())
 }
 
 // Hardware management
-async fn execute_gpu() -> Result<HashMap<String, Vec<f32>>, SessionError> {
+async fn execute_gpu() -> Result<HashMap<String, OutputTensor>, SessionError> {
     // USER INPUT
     let n = 5;
     let c = 1;

--- a/wonnx/examples/squeeze.rs
+++ b/wonnx/examples/squeeze.rs
@@ -2,6 +2,7 @@ use image::{imageops::FilterType, ImageBuffer, Pixel, Rgb};
 use log::info;
 use ndarray::s;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::time::Instant;
 use std::{
     fs,
@@ -15,7 +16,7 @@ use wonnx::WonnxError;
 async fn run() {
     let probabilities = execute_gpu().await.unwrap();
     let probabilities = probabilities.into_iter().next().unwrap().1;
-    let probabilities = probabilities.as_f32().unwrap();
+    let probabilities: Vec<f32> = probabilities.try_into().unwrap();
     let mut probabilities = probabilities.iter().enumerate().collect::<Vec<_>>();
     probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(a.1).unwrap());
 

--- a/wonnx/examples/squeeze.rs
+++ b/wonnx/examples/squeeze.rs
@@ -8,12 +8,14 @@ use std::{
     io::{BufRead, BufReader},
     path::Path,
 };
+use wonnx::utils::OutputTensor;
 use wonnx::WonnxError;
 
 // Args Management
 async fn run() {
-    let probabilities = &execute_gpu().await.unwrap();
-    let (_, probabilities) = probabilities.iter().next().unwrap();
+    let probabilities = execute_gpu().await.unwrap();
+    let probabilities = probabilities.into_iter().next().unwrap().1;
+    let probabilities = probabilities.as_f32().unwrap();
     let mut probabilities = probabilities.iter().enumerate().collect::<Vec<_>>();
     probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(a.1).unwrap());
 
@@ -28,7 +30,7 @@ async fn run() {
 }
 
 // Hardware management
-async fn execute_gpu() -> Result<HashMap<String, Vec<f32>>, WonnxError> {
+async fn execute_gpu() -> Result<HashMap<String, OutputTensor>, WonnxError> {
     let mut input_data = HashMap::new();
     let image = load_image();
     input_data.insert("data".to_string(), image.as_slice().unwrap().into());

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -5,6 +5,7 @@ use std::{
     sync::Arc,
 };
 
+use num::FromPrimitive;
 use thiserror::Error;
 use wgpu::{Buffer, BufferUsages, CommandEncoder};
 

--- a/wonnx/src/lib.rs
+++ b/wonnx/src/lib.rs
@@ -17,7 +17,7 @@ use protobuf::{self, Message, ProtobufError};
 use std::collections::HashMap;
 use std::path::Path;
 use std::result::Result;
-use utils::{DataTypeError, InputTensor};
+use utils::{DataTypeError, InputTensor, OutputTensor};
 
 use crate::gpu::GpuModel;
 use thiserror::Error;
@@ -144,7 +144,7 @@ impl Session {
     pub async fn run<'a>(
         &self,
         inputs: &HashMap<String, InputTensor<'a>>,
-    ) -> Result<HashMap<String, Vec<f32>>, SessionError> {
+    ) -> Result<HashMap<String, OutputTensor>, SessionError> {
         Ok(self.gpu_model.infer(inputs).await?)
     }
 }

--- a/wonnx/tests/arithmetic.rs
+++ b/wonnx/tests/arithmetic.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::{
     onnx::TensorProto_DataType,
     utils::{
@@ -56,7 +56,10 @@ fn test_reciprocal() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), reciprocal_data.as_slice());
+    common::assert_eq_vector(
+        (&result["Y"]).try_into().unwrap(),
+        reciprocal_data.as_slice(),
+    );
 }
 
 #[test]

--- a/wonnx/tests/arithmetic.rs
+++ b/wonnx/tests/arithmetic.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use wonnx::{
     onnx::TensorProto_DataType,
-    utils::{graph, initializer_int64, model, node, tensor, tensor_of_type, InputTensor},
+    utils::{
+        graph, initializer_int64, model, node, tensor, tensor_of_type, InputTensor, OutputTensor,
+    },
 };
 
 mod common;
@@ -28,7 +30,7 @@ fn test_cos() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    assert_eq!(result["Y"], [1.0; 16]);
+    assert_eq!(result["Y"], OutputTensor::F32(vec![1.0; 16]));
 }
 
 #[test]
@@ -54,7 +56,7 @@ fn test_reciprocal() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    common::assert_eq_vector(result["Y"].as_slice(), &reciprocal_data);
+    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), reciprocal_data.as_slice());
 }
 
 #[test]
@@ -80,7 +82,7 @@ fn test_integer() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    assert_eq!(result["Y"], vec![42.0; n]);
+    assert_eq!(result["Y"], OutputTensor::I32(vec![42; n]));
 }
 
 #[test]
@@ -89,7 +91,7 @@ fn test_int64_initializers() {
     let n: usize = 16;
     let left: Vec<i64> = (0..n).map(|x| x as i64).collect();
     let right: Vec<i64> = (0..n).map(|x| (x * 2) as i64).collect();
-    let sum: Vec<f32> = (0..n).map(|x| (x * 3) as f32).collect();
+    let sum: Vec<i64> = (0..n).map(|x| (x * 3) as i64).collect();
     let dims = vec![n as i64];
 
     let model = model(graph(
@@ -107,5 +109,5 @@ fn test_int64_initializers() {
     input_data.insert("X".to_string(), left.as_slice().into());
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    common::assert_eq_vector(result["Z"].as_slice(), &sum);
+    assert_eq!(result["Z"], OutputTensor::I64(sum))
 }

--- a/wonnx/tests/batchnormalization.rs
+++ b/wonnx/tests/batchnormalization.rs
@@ -62,7 +62,7 @@ fn batch_normalization() {
     let out_y = &result["Y"];
 
     common::assert_eq_vector(
-        out_y.as_slice(),
+        out_y.unwrap_f32_slice(),
         &[
             // Y = (X - input_mean) / sqrt(input_var + epsilon) * scale + B
             // For X=0, Y = (0 - 100) / sqrt(10 + 0.1) * 1 + 1000 = 968,53

--- a/wonnx/tests/batchnormalization.rs
+++ b/wonnx/tests/batchnormalization.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::utils::{attribute, graph, initializer, model, node, tensor};
 mod common;
 
@@ -62,7 +62,7 @@ fn batch_normalization() {
     let out_y = &result["Y"];
 
     common::assert_eq_vector(
-        out_y.unwrap_f32_slice(),
+        out_y.try_into().unwrap(),
         &[
             // Y = (X - input_mean) / sqrt(input_var + epsilon) * scale + B
             // For X=0, Y = (0 - 100) / sqrt(10 + 0.1) * 1 + 1000 = 968,53

--- a/wonnx/tests/cast.rs
+++ b/wonnx/tests/cast.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use protobuf::ProtobufEnum;
 use wonnx::{
     onnx::TensorProto_DataType,
-    utils::{attribute, graph, model, node, tensor, tensor_of_type},
+    utils::{attribute, graph, model, node, tensor, tensor_of_type, OutputTensor},
 };
 
 #[test]
@@ -37,6 +37,6 @@ fn test_cast() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     assert_eq!(
         result["Y"],
-        vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 5.0]
+        OutputTensor::I32(vec![0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5])
     );
 }

--- a/wonnx/tests/conv.rs
+++ b/wonnx/tests/conv.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
-use wonnx::utils::{attribute, graph, initializer, model, node, tensor};
+use wonnx::utils::{attribute, graph, initializer, model, node, tensor, OutputTensor};
 use wonnx::*;
+mod common;
 
 #[test]
 fn conv_pad() {
@@ -36,7 +37,7 @@ fn conv_pad() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     assert_eq!(
         result["Y"],
-        [
+        OutputTensor::F32(vec![
             12.0, 21.0, 27.0, 33.0, 24.0, 33.0, 54.0, 63.0, 72.0, 51.0, 63.0, 99.0, 108.0, 117.0,
             81.0, 93.0, 144.0, 153.0, 162.0, 111.0, 72.0, 111.0, 117.0, 123.0, 84.0, 12.0, 21.0,
             27.0, 33.0, 24.0, 33.0, 54.0, 63.0, 72.0, 51.0, 63.0, 99.0, 108.0, 117.0, 81.0, 93.0,
@@ -45,7 +46,7 @@ fn conv_pad() {
             243.0, 369.0, 378.0, 387.0, 261.0, 172.0, 261.0, 267.0, 273.0, 184.0, 112.0, 171.0,
             177.0, 183.0, 124.0, 183.0, 279.0, 288.0, 297.0, 201.0, 213.0, 324.0, 333.0, 342.0,
             231.0, 243.0, 369.0, 378.0, 387.0, 261.0, 172.0, 261.0, 267.0, 273.0, 184.0
-        ]
+        ])
     );
 }
 
@@ -79,10 +80,10 @@ fn conv_without_pad() {
     let session =
         pollster::block_on(wonnx::Session::from_model(conv_model)).expect("Session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    assert_eq!(
-        result["Y"],
-        [54., 63., 72., 99., 108., 117., 144., 153., 162.]
-    );
+    common::assert_eq_vector(
+        result["Y"].unwrap_f32_slice(),
+        &[54., 63., 72., 99., 108., 117., 144., 153., 162.],
+    )
 }
 
 #[test]
@@ -131,10 +132,12 @@ fn conv_stride() {
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    assert_eq!(
-        result["Y"],
-        [12., 27., 24., 63., 108., 81., 123., 198., 141., 112., 177., 124.]
-    );
+    common::assert_eq_vector(
+        result["Y"].unwrap_f32_slice(),
+        &[
+            12., 27., 24., 63., 108., 81., 123., 198., 141., 112., 177., 124.,
+        ],
+    )
 }
 
 #[test]
@@ -173,7 +176,10 @@ fn conv_asymetric_stride() {
     let session =
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    assert_eq!(result["Y"], [21., 33., 99., 117., 189., 207., 171., 183.]);
+    common::assert_eq_vector(
+        result["Y"].unwrap_f32_slice(),
+        &[21., 33., 99., 117., 189., 207., 171., 183.],
+    );
 }
 
 fn _conv_kernel_3() {

--- a/wonnx/tests/conv.rs
+++ b/wonnx/tests/conv.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryInto;
 use wonnx::utils::{attribute, graph, initializer, model, node, tensor, OutputTensor};
 use wonnx::*;
 mod common;
@@ -81,7 +82,7 @@ fn conv_without_pad() {
         pollster::block_on(wonnx::Session::from_model(conv_model)).expect("Session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     common::assert_eq_vector(
-        result["Y"].unwrap_f32_slice(),
+        (&result["Y"]).try_into().unwrap(),
         &[54., 63., 72., 99., 108., 117., 144., 153., 162.],
     )
 }
@@ -133,7 +134,7 @@ fn conv_stride() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
     common::assert_eq_vector(
-        result["Y"].unwrap_f32_slice(),
+        (&result["Y"]).try_into().unwrap(),
         &[
             12., 27., 24., 63., 108., 81., 123., 198., 141., 112., 177., 124.,
         ],
@@ -177,7 +178,7 @@ fn conv_asymetric_stride() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     common::assert_eq_vector(
-        result["Y"].unwrap_f32_slice(),
+        (&result["Y"]).try_into().unwrap(),
         &[21., 33., 99., 117., 189., 207., 171., 183.],
     );
 }

--- a/wonnx/tests/gather.rs
+++ b/wonnx/tests/gather.rs
@@ -35,7 +35,7 @@ fn assert_gather(
         pollster::block_on(wonnx::Session::from_model(bn_model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    common::assert_eq_vector(result["Y"].as_slice(), output);
+    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), output);
 }
 
 #[test]

--- a/wonnx/tests/gather.rs
+++ b/wonnx/tests/gather.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::utils::{attribute, graph, model, node, tensor};
 mod common;
 
@@ -35,7 +35,7 @@ fn assert_gather(
         pollster::block_on(wonnx::Session::from_model(bn_model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), output);
+    common::assert_eq_vector((&result["Y"]).try_into().unwrap(), output);
 }
 
 #[test]

--- a/wonnx/tests/globalaveragepool.rs
+++ b/wonnx/tests/globalaveragepool.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::utils::{graph, model, node, tensor};
 mod common;
 
@@ -49,5 +49,5 @@ fn global_average_pool() {
     // Channel 2: [[4,5], [6,7]] => average is 5,5
     // Channel 3: [[8,9], [10, 11]] => average is 9,5
     // Channel 4: [[12,13], [14, 15]] => average is 13,5
-    common::assert_eq_vector(out_y.unwrap_f32_slice(), &[1.5, 5.5, 9.5, 13.5]);
+    common::assert_eq_vector(out_y.try_into().unwrap(), &[1.5, 5.5, 9.5, 13.5]);
 }

--- a/wonnx/tests/globalaveragepool.rs
+++ b/wonnx/tests/globalaveragepool.rs
@@ -49,5 +49,5 @@ fn global_average_pool() {
     // Channel 2: [[4,5], [6,7]] => average is 5,5
     // Channel 3: [[8,9], [10, 11]] => average is 9,5
     // Channel 4: [[12,13], [14, 15]] => average is 13,5
-    common::assert_eq_vector(out_y.as_slice(), &[1.5, 5.5, 9.5, 13.5]);
+    common::assert_eq_vector(out_y.unwrap_f32_slice(), &[1.5, 5.5, 9.5, 13.5]);
 }

--- a/wonnx/tests/identity.rs
+++ b/wonnx/tests/identity.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use wonnx::utils::{graph, model, node, tensor};
+mod common;
 
 #[test]
 fn test_identity() {
@@ -23,7 +24,7 @@ fn test_identity() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    assert_eq!(result["Y"], data);
+    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), &data);
 }
 
 #[test]
@@ -51,5 +52,5 @@ fn test_double_identity() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    assert_eq!(result["Z"], data);
+    common::assert_eq_vector(result["Z"].unwrap_f32_slice(), &data);
 }

--- a/wonnx/tests/identity.rs
+++ b/wonnx/tests/identity.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::utils::{graph, model, node, tensor};
 mod common;
 
@@ -24,7 +24,7 @@ fn test_identity() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), &data);
+    common::assert_eq_vector((&result["Y"]).try_into().unwrap(), &data);
 }
 
 #[test]
@@ -52,5 +52,5 @@ fn test_double_identity() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
-    common::assert_eq_vector(result["Z"].unwrap_f32_slice(), &data);
+    common::assert_eq_vector((&result["Z"]).try_into().unwrap(), &data);
 }

--- a/wonnx/tests/matrix.rs
+++ b/wonnx/tests/matrix.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use wonnx::utils::{attribute, graph, initializer, model, node, tensor};
+mod common;
 
 #[test]
 fn test_matmul_square_matrix() {
@@ -34,10 +35,9 @@ fn test_matmul_square_matrix() {
 
     let session =
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
-
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    assert_eq!(result["C"].as_slice(), sum.as_slice().unwrap());
+    common::assert_eq_vector(result["C"].unwrap_f32_slice(), sum.as_slice().unwrap());
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_two_transposes() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    assert_eq!(result["Z"], data);
+    common::assert_eq_vector(result["Z"].unwrap_f32_slice(), &data);
 }
 
 #[test]
@@ -102,9 +102,9 @@ fn test_split() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
     let test_y = vec![1., 2., 3., 7., 8., 9.];
-    assert_eq!(result["Y"], test_y);
+    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), &test_y);
     let test_w = vec![4., 5., 6., 10., 11., 12.];
-    assert_eq!(result["W"], test_w);
+    common::assert_eq_vector(result["W"].unwrap_f32_slice(), &test_w);
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn test_resize() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
     let test_y = vec![1., 3.];
-    assert_eq!(result["Y"], test_y);
+    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), &test_y);
 
     let mut input_data = HashMap::new();
     let data = (1..=4).map(|x| x as f32).collect::<Vec<f32>>();

--- a/wonnx/tests/matrix.rs
+++ b/wonnx/tests/matrix.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::utils::{attribute, graph, initializer, model, node, tensor};
 mod common;
 
@@ -37,7 +37,7 @@ fn test_matmul_square_matrix() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    common::assert_eq_vector(result["C"].unwrap_f32_slice(), sum.as_slice().unwrap());
+    common::assert_eq_vector((&result["C"]).try_into().unwrap(), sum.as_slice().unwrap());
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn test_two_transposes() {
         pollster::block_on(wonnx::Session::from_model(model)).expect("session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    common::assert_eq_vector(result["Z"].unwrap_f32_slice(), &data);
+    common::assert_eq_vector((&result["Z"]).try_into().unwrap(), &data);
 }
 
 #[test]
@@ -102,9 +102,9 @@ fn test_split() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
     let test_y = vec![1., 2., 3., 7., 8., 9.];
-    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), &test_y);
+    common::assert_eq_vector((&result["Y"]).try_into().unwrap(), &test_y);
     let test_w = vec![4., 5., 6., 10., 11., 12.];
-    common::assert_eq_vector(result["W"].unwrap_f32_slice(), &test_w);
+    common::assert_eq_vector((&result["W"]).try_into().unwrap(), &test_w);
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn test_resize() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
     let test_y = vec![1., 3.];
-    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), &test_y);
+    common::assert_eq_vector((&result["Y"]).try_into().unwrap(), &test_y);
 
     let mut input_data = HashMap::new();
     let data = (1..=4).map(|x| x as f32).collect::<Vec<f32>>();

--- a/wonnx/tests/onehot.rs
+++ b/wonnx/tests/onehot.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::{
     onnx::AttributeProto,
     utils::{attribute, graph, model, node, tensor, InputTensor},
@@ -50,7 +50,7 @@ fn test_onehot(
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     log::info!("OUT: {:?}", result["Y"]);
-    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), output);
+    common::assert_eq_vector((&result["Y"]).try_into().unwrap(), output);
 }
 
 #[test]

--- a/wonnx/tests/onehot.rs
+++ b/wonnx/tests/onehot.rs
@@ -50,7 +50,7 @@ fn test_onehot(
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     log::info!("OUT: {:?}", result["Y"]);
-    common::assert_eq_vector(result["Y"].as_slice(), output);
+    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), output);
 }
 
 #[test]

--- a/wonnx/tests/pretrained_models.rs
+++ b/wonnx/tests/pretrained_models.rs
@@ -2,6 +2,7 @@ use image::{imageops::FilterType, ImageBuffer, Pixel, Rgb};
 use ndarray::s;
 use std::collections::HashMap;
 use std::path::Path;
+mod common;
 
 #[test]
 fn test_relu() {
@@ -13,7 +14,7 @@ fn test_relu() {
         .expect("session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    assert_eq!(result["y"], &[0.0, 1.0]);
+    common::assert_eq_vector(result["y"].unwrap_f32_slice(), &[0.0, 1.0]);
 }
 
 #[test]
@@ -26,6 +27,7 @@ fn test_mnist() {
         .expect("Session did not create");
 
     let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
+        .unwrap_f32_slice()
         .iter()
         .enumerate()
         .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
@@ -42,6 +44,7 @@ fn test_mnist() {
     let mut input_data = HashMap::new();
     input_data.insert("Input3".to_string(), image.as_slice().unwrap().into());
     let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
+        .unwrap_f32_slice()
         .iter()
         .enumerate()
         .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
@@ -58,6 +61,7 @@ fn test_mnist() {
     let mut input_data = HashMap::new();
     input_data.insert("Input3".to_string(), image.as_slice().unwrap().into());
     let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
+        .unwrap_f32_slice()
         .iter()
         .enumerate()
         .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
@@ -74,6 +78,7 @@ fn test_mnist() {
     let mut input_data = HashMap::new();
     input_data.insert("Input3".to_string(), image.as_slice().unwrap().into());
     let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
+        .unwrap_f32_slice()
         .iter()
         .enumerate()
         .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
@@ -100,9 +105,14 @@ fn test_squeeze() {
         .expect("session did not create");
     let result =
         &pollster::block_on(session.run(&input_data)).unwrap()["squeezenet0_flatten0_reshape0"];
-    let mut probabilities = result.iter().enumerate().collect::<Vec<_>>();
+    let mut probabilities: Vec<(usize, f32)> = result
+        .unwrap_f32_slice()
+        .iter()
+        .cloned()
+        .enumerate()
+        .collect();
 
-    probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(a.1).unwrap());
+    probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
 
     assert_eq!(probabilities[0].0, 22);
 }

--- a/wonnx/tests/pretrained_models.rs
+++ b/wonnx/tests/pretrained_models.rs
@@ -1,7 +1,9 @@
 use image::{imageops::FilterType, ImageBuffer, Pixel, Rgb};
 use ndarray::s;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::path::Path;
+use wonnx::utils::InputTensor;
 mod common;
 
 #[test]
@@ -14,81 +16,46 @@ fn test_relu() {
         .expect("session did not create");
     let result = pollster::block_on(session.run(&input_data)).unwrap();
 
-    common::assert_eq_vector(result["y"].unwrap_f32_slice(), &[0.0, 1.0]);
+    common::assert_eq_vector((&result["y"]).try_into().unwrap(), &[0.0, 1.0]);
+}
+
+fn infer_mnist(image: InputTensor) -> (usize, f32) {
+    let session = pollster::block_on(wonnx::Session::from_path("../data/models/opt-mnist.onnx"))
+        .expect("Session did not create");
+
+    let mut input_data = HashMap::new();
+    input_data.insert("Input3".to_string(), image);
+    let output = pollster::block_on(session.run(&input_data)).unwrap();
+    let output_tensor: &[f32] = (&output["Plus214_Output_0"]).try_into().unwrap();
+    output_tensor
+        .iter()
+        .enumerate()
+        .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
+            if &val_max > val {
+                (idx_max, val_max)
+            } else {
+                (idx, *val)
+            }
+        })
 }
 
 #[test]
 fn test_mnist() {
     let _ = env_logger::builder().is_test(true).try_init();
     let image = load_image("0.jpg");
-    let mut input_data = HashMap::new();
-    input_data.insert("Input3".to_string(), image.as_slice().unwrap().into());
-    let session = pollster::block_on(wonnx::Session::from_path("../data/models/opt-mnist.onnx"))
-        .expect("Session did not create");
-
-    let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
-        .unwrap_f32_slice()
-        .iter()
-        .enumerate()
-        .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
-            if &val_max > val {
-                (idx_max, val_max)
-            } else {
-                (idx, *val)
-            }
-        });
-
+    let result = infer_mnist(image.as_slice().unwrap().into());
     assert_eq!(result.0, 0);
 
     let image = load_image("3.jpg");
-    let mut input_data = HashMap::new();
-    input_data.insert("Input3".to_string(), image.as_slice().unwrap().into());
-    let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
-        .unwrap_f32_slice()
-        .iter()
-        .enumerate()
-        .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
-            if &val_max > val {
-                (idx_max, val_max)
-            } else {
-                (idx, *val)
-            }
-        });
-
+    let result = infer_mnist(image.as_slice().unwrap().into());
     assert_eq!(result.0, 3);
 
     let image = load_image("5.jpg");
-    let mut input_data = HashMap::new();
-    input_data.insert("Input3".to_string(), image.as_slice().unwrap().into());
-    let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
-        .unwrap_f32_slice()
-        .iter()
-        .enumerate()
-        .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
-            if &val_max > val {
-                (idx_max, val_max)
-            } else {
-                (idx, *val)
-            }
-        });
-
+    let result = infer_mnist(image.as_slice().unwrap().into());
     assert_eq!(result.0, 5);
 
     let image = load_image("7.jpg");
-    let mut input_data = HashMap::new();
-    input_data.insert("Input3".to_string(), image.as_slice().unwrap().into());
-    let result = pollster::block_on(session.run(&input_data)).unwrap()["Plus214_Output_0"]
-        .unwrap_f32_slice()
-        .iter()
-        .enumerate()
-        .fold((0, 0.), |(idx_max, val_max), (idx, val)| {
-            if &val_max > val {
-                (idx_max, val_max)
-            } else {
-                (idx, *val)
-            }
-        });
-
+    let result = infer_mnist(image.as_slice().unwrap().into());
     assert_eq!(result.0, 7);
 }
 
@@ -105,12 +72,8 @@ fn test_squeeze() {
         .expect("session did not create");
     let result =
         &pollster::block_on(session.run(&input_data)).unwrap()["squeezenet0_flatten0_reshape0"];
-    let mut probabilities: Vec<(usize, f32)> = result
-        .unwrap_f32_slice()
-        .iter()
-        .cloned()
-        .enumerate()
-        .collect();
+    let output_tensor: &[f32] = result.try_into().unwrap();
+    let mut probabilities: Vec<(usize, f32)> = output_tensor.iter().cloned().enumerate().collect();
 
     probabilities.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
 

--- a/wonnx/tests/reduce.rs
+++ b/wonnx/tests/reduce.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 use wonnx::{
     onnx::AttributeProto,
     utils::{attribute, graph, initializer_int64, model, node, tensor},
@@ -38,7 +38,7 @@ fn test_reduce(
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     log::info!("OUT: {:?}", result["Y"]);
-    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), output);
+    common::assert_eq_vector((&result["Y"]).try_into().unwrap(), output);
 }
 
 fn sum_square(a: f32, b: f32) -> f32 {
@@ -277,7 +277,7 @@ fn test_reduce_sum_with_axes_as_input() {
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     log::info!("OUT: {:?}", result["Y"]);
     common::assert_eq_vector(
-        result["Y"].unwrap_f32_slice(),
+        (&result["Y"]).try_into().unwrap(),
         &[4., 6., 12., 14., 20., 22.],
     );
 }

--- a/wonnx/tests/reduce.rs
+++ b/wonnx/tests/reduce.rs
@@ -38,7 +38,7 @@ fn test_reduce(
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     log::info!("OUT: {:?}", result["Y"]);
-    common::assert_eq_vector(result["Y"].as_slice(), output);
+    common::assert_eq_vector(result["Y"].unwrap_f32_slice(), output);
 }
 
 fn sum_square(a: f32, b: f32) -> f32 {
@@ -276,5 +276,8 @@ fn test_reduce_sum_with_axes_as_input() {
 
     let result = pollster::block_on(session.run(&input_data)).unwrap();
     log::info!("OUT: {:?}", result["Y"]);
-    common::assert_eq_vector(result["Y"].as_slice(), &[4., 6., 12., 14., 20., 22.]);
+    common::assert_eq_vector(
+        result["Y"].unwrap_f32_slice(),
+        &[4., 6., 12., 14., 20., 22.],
+    );
 }


### PR DESCRIPTION
This PR implements support for output types other than Vec<f32>. 

## Implementation details

Output tensors are wrapped in an enum `OutputTensor` (e.g. `OutputTensor::F32(Vec<f32>)`). The difference with `InputTensor<'a>` is that the output tensor always owns its values. It defines a convenience method `.as_f32()` to convert to `Vec<f32>` (propagating any conversion errors) as well as a `.unwrap_f32_slice()` that supplies an `&[f32]` for tensors that you know will be of f32 type. For JS/WASM and Python, the OutputTensor is converted using the appropriate methods.

This is based on #69, so perhaps merge that one first. 