### PR TITLE
feat: feed shape info to initializer

### DIFF
--- a/wonnx/examples/simple_graph.rs
+++ b/wonnx/examples/simple_graph.rs
@@ -32,7 +32,7 @@ async fn execute_gpu() -> Result<HashMap<String, Vec<f32>>, SessionError> {
         vec![tensor("X", &shape)],
         vec![tensor("Y", &[1, m, 3, 3])],
         vec![tensor("W", &[m, c, 3, 3])],
-        vec![initializer("W", data_w)],
+        vec![initializer("W", data_w, vec![m, c, 3, 3])],
         vec![node(
             vec!["X", "W"],
             vec!["Y"],

--- a/wonnx/src/utils.rs
+++ b/wonnx/src/utils.rs
@@ -311,8 +311,13 @@ pub fn tensor_of_type(
     tensor
 }
 
-pub fn initializer(name: &str, data: Vec<f32>) -> onnx::TensorProto {
+pub fn initializer(name: &str, data: Vec<f32>, dimensions: Vec<i64>) -> onnx::TensorProto {
     let mut initializer = crate::onnx::TensorProto::new();
+    debug_assert_eq!(
+        dimensions.iter().cloned().product::<i64>() as usize,
+        data.len()
+    );
+    initializer.set_dims(dimensions);
     initializer.set_name(name.to_string());
     initializer.set_data_type(TensorProto_DataType::FLOAT.value());
     initializer.set_float_data(data);
@@ -488,7 +493,7 @@ mod tests {
             vec![tensor("X", &shape)],
             vec![tensor("Y", &[1, 1, 3, 3])],
             vec![tensor("W", &[2, c, 3, 3])],
-            vec![initializer("W", data_w)],
+            vec![initializer("W", data_w, vec![2, c, 3, 3])],
             vec![node(
                 vec!["X", "W"],
                 vec!["Y"],

--- a/wonnx/tests/batchnormalization.rs
+++ b/wonnx/tests/batchnormalization.rs
@@ -40,10 +40,10 @@ fn batch_normalization() {
             tensor("input_var", &[channels as i64]),
         ],
         vec![
-            initializer("scale", scale),
-            initializer("B", b),
-            initializer("input_mean", mean),
-            initializer("input_var", var),
+            initializer("scale", scale, vec![channels as i64]),
+            initializer("B", b, vec![channels as i64]),
+            initializer("input_mean", mean, vec![channels as i64]),
+            initializer("input_var", var, vec![channels as i64]),
         ],
         vec![node(
             vec!["X", "scale", "B", "input_mean", "input_var"],

--- a/wonnx/tests/conv.rs
+++ b/wonnx/tests/conv.rs
@@ -18,7 +18,7 @@ fn conv_pad() {
         vec![tensor("X", &shape)],
         vec![tensor("Y", &[2, 2, n, n])],
         vec![tensor("W", &[2, c, 3, 3])],
-        vec![initializer("W", data_w)],
+        vec![initializer("W", data_w, vec![2, c, 3, 3])],
         vec![node(
             vec!["X", "W"],
             vec!["Y"],
@@ -65,8 +65,8 @@ fn conv_without_pad() {
     let conv_model = model(graph(
         vec![tensor("X", &shape)],
         vec![tensor("Y", &[1, 1, 3, 3])],
-        vec![tensor("W", &[2, c, 3, 3])],
-        vec![initializer("W", data_w)],
+        vec![tensor("W", &[m, c, kernel_n, kernel_n])],
+        vec![initializer("W", data_w, vec![m, c, kernel_n, kernel_n])],
         vec![node(
             vec!["X", "W"],
             vec!["Y"],
@@ -110,7 +110,11 @@ fn conv_stride() {
             "W",
             &[m as i64, c as i64, kernel_n as i64, kernel_n as i64],
         )],
-        vec![initializer("W", data_w)],
+        vec![initializer(
+            "W",
+            data_w,
+            vec![m as i64, c as i64, kernel_n as i64, kernel_n as i64],
+        )],
         vec![node(
             vec!["X", "W"],
             vec!["Y"],
@@ -156,7 +160,11 @@ fn conv_asymetric_stride() {
             "W",
             &[m as i64, c as i64, kernel_n as i64, kernel_n as i64],
         )],
-        vec![initializer("W", data_w)],
+        vec![initializer(
+            "W",
+            data_w,
+            vec![m as i64, c as i64, kernel_n as i64, kernel_n as i64],
+        )],
         vec![node(
             vec!["X", "W"],
             vec!["Y"],

--- a/wonnx/tests/matrix.rs
+++ b/wonnx/tests/matrix.rs
@@ -118,7 +118,7 @@ fn test_resize() {
         vec![tensor("X", &[1, 1, 2, 4])],
         vec![tensor("Y", &[1, 1, 1, 2])],
         vec![],
-        vec![initializer("scales", vec![1., 1., 0.6, 0.6])],
+        vec![initializer("scales", vec![1., 1., 0.6, 0.6], vec![4])],
         vec![node(
             vec!["X", "" /* roi */, "scales"],
             vec!["Y"],
@@ -143,7 +143,7 @@ fn test_resize() {
         vec![tensor("X", &[1, 1, 2, 2])],
         vec![tensor("Y", &[1, 1, 4, 6])],
         vec![],
-        vec![initializer("scales", vec![1., 1., 2., 3.])],
+        vec![initializer("scales", vec![1., 1., 2., 3.], vec![4])],
         vec![node(
             vec!["X", "" /* roi */, "scales"],
             vec!["Y"],


### PR DESCRIPTION
fixes #66 

Turns out that `initializer` inited info proto will not include the shape info. This PR forces callers to provide shape information to ensure that any shaders using the info would not crash