### PR TITLE
fix: upgrade to newer WGSL syntax

### DIFF
--- a/wonnx/templates/endomorphism/activation.wgsl
+++ b/wonnx/templates/endomorphism/activation.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: ArrayVector;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size({{ workgroup_size_x }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{% set activation_input = "input_0.data[gidx]" %}

--- a/wonnx/templates/endomorphism/arithmetic.wgsl
+++ b/wonnx/templates/endomorphism/arithmetic.wgsl
@@ -1,25 +1,25 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
 {% if i_lens | length == 2 %}
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: ArrayVector;
 
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, write> output_0: ArrayVector;
 
 {% else %}
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: ArrayVector;
 
 {% endif %}
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size({{ workgroup_size_x }}, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{% if i_lens | length == 2 %}

--- a/wonnx/templates/endomorphism/batchnormalization.wgsl
+++ b/wonnx/templates/endomorphism/batchnormalization.wgsl
@@ -2,35 +2,35 @@
 {%- include "structs.wgsl" -%}
 
 struct Block {
-	data: [[stride({{ elem_stride }})]] array<{{ elem_type }}>;
+	data: array<{{ elem_type }}>,
 };
 
 // X (input)
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Block;
 
 // Scale
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Array;
 
 // B (bias)
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, read> input_2: Array;
 
 // Input mean
-[[group(0), binding(3)]]
+@group(0) @binding(3)
 var<storage, read> input_3: Array;
 
 // Input variance
-[[group(1), binding(0)]]
+@group(1) @binding(0)
 var<storage, read> input_4: Array;
 
 // Y (Output)
-[[group(1), binding(1)]]
+@group(1) @binding(1)
 var<storage, write> output_0: Block;
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let channel = global_id.y;
 	let batch = global_id.z;
 	let index = global_id.x + batch * {{ batch_size }}u + channel * {{ channel_size }}u;

--- a/wonnx/templates/endomorphism/cast.wgsl
+++ b/wonnx/templates/endomorphism/cast.wgsl
@@ -1,16 +1,16 @@
 {%- include "structs.wgsl" -%}
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
 struct OutputArrayVector {
-	data: [[stride({{ vec4_stride }})]] array<vec4<{{ cast_to_type }}>>;
+	data: array<vec4<{{ cast_to_type }}>>,
 }; 
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: OutputArrayVector;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size({{ workgroup_size_x }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let gidx = global_id.x;
     output_0.data[gidx] = vec4<{{ cast_to_type }}>(input_0.data[gidx]);
 }

--- a/wonnx/templates/endomorphism/gather.wgsl
+++ b/wonnx/templates/endomorphism/gather.wgsl
@@ -1,24 +1,24 @@
 {%- include "structs.wgsl" -%}
 
 struct Indices {
-	data: [[stride(4)]] array<i32>;
+	data: array<i32>,
 };
 
 struct Chunk {
-	data: [[stride({{ scalar_stride * chunk_size }})]] array<{{ chunk_type }}>;
+	data: array<{{ chunk_type }}>,
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Chunk; // data
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Indices; // indices
 
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, write> output_0: Chunk;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let index_index = global_id.x; // Index of the index in the indices array that we are currently processing
 	let chunk_index = global_id.y; // Chunk of elements that we are copying for this index (chunk size determined dynamically)
 	let index_stride = {{ i_chunks[0][0] / chunk_size }}u;

--- a/wonnx/templates/endomorphism/map.wgsl
+++ b/wonnx/templates/endomorphism/map.wgsl
@@ -1,12 +1,12 @@
 {%- include "structs.wgsl" -%}
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: ArrayVector;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size({{ workgroup_size_x }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	
 	{% if op_type == "Reciprocal" %}

--- a/wonnx/templates/endomorphism/onehot.wgsl
+++ b/wonnx/templates/endomorphism/onehot.wgsl
@@ -1,27 +1,27 @@
 {%- include "structs.wgsl" -%}
 
 struct Indices {
-	data: [[stride(4)]] array<i32>;
+	data: array<i32>,
 };
 
 struct Depth {
-	data: i32;
+	data: i32,
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_indexes: Indices;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_depth: Depth;
 
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, read> input_values: Array;
 
-[[group(0), binding(3)]]
+@group(0) @binding(3)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let index_of_index = global_id.x;
 	let depth = u32(input_depth.data);
 	var index = input_indexes.data[index_of_index];

--- a/wonnx/templates/endomorphism/softmax.wgsl
+++ b/wonnx/templates/endomorphism/softmax.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	let chunk_start = gidx * {{ axis_chunk }}u + global_id.y;
 

--- a/wonnx/templates/matrix/concat.wgsl
+++ b/wonnx/templates/matrix/concat.wgsl
@@ -3,17 +3,17 @@
 
 {% for input in i_lens %}
 
-[[group({{ loop.index0 / 4 | int }}), binding({{ loop.index0 % 4}})]]
+@group({{ loop.index0 / 4 | int }}) @binding({{ loop.index0 % 4}})
 var<storage, read> input_{{ loop.index0 }}: Array;
 
 {% endfor %}
 
 {% set binding_len = i_lens | length %}
-[[group({{ binding_len  / 4 | int }}), binding({{ binding_len % 4 }})]]
+@group({{ binding_len  / 4 | int }}) @binding({{ binding_len % 4 }})
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	
 	{% for input in i_lens %}

--- a/wonnx/templates/matrix/gemm.wgsl
+++ b/wonnx/templates/matrix/gemm.wgsl
@@ -1,24 +1,24 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: ArrayVector;
 
 {%- if i_lens | length == 3 -%} // Bias
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, read> input_2: ArrayVector;
 
-[[group(0), binding(3)]]
+@group(0) @binding(3)
 var<storage, write> output_0: ArrayVector;
 {%- else -%}
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, write> output_0: ArrayVector;
 {%- endif -%}  
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let y = global_id.x % {{ i_shape[1][1] / 4 | int }}u;
 	let x = global_id.x / {{ i_shape[1][1] / 4 | int }}u;
 	let index = x * {{ i_shape[1][1] }}u + y;

--- a/wonnx/templates/matrix/gemm_1.wgsl
+++ b/wonnx/templates/matrix/gemm_1.wgsl
@@ -1,26 +1,26 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Array;
 
 {%- if i_lens | length == 3 -%} // Bias
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, read> input_2: Array;
 
-[[group(0), binding(3)]]
+@group(0) @binding(3)
 var<storage, write> output_0: Array;
 
 {%- else -%}
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, write> output_0: Array;
 
 {%- endif -%}  
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	var tmpsum = Scalar(0);

--- a/wonnx/templates/matrix/resize.wgsl
+++ b/wonnx/templates/matrix/resize.wgsl
@@ -1,14 +1,14 @@
 
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	if (gidx < {{ o_lens[0] }}u) {

--- a/wonnx/templates/matrix/split.wgsl
+++ b/wonnx/templates/matrix/split.wgsl
@@ -1,16 +1,16 @@
 
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
 {% for output in o_lens %}
-	[[group({{ loop.index / 4 | int }}), binding({{ loop.index % 4}})]]
+	@group({{ loop.index / 4 | int }}) @binding({{ loop.index % 4}})
 	var<storage, write> output_{{ loop.index0 }}: Array;
 {% endfor %}
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	if (gidx < {{ i_lens[0] }}u) {

--- a/wonnx/templates/matrix/transpose.wgsl
+++ b/wonnx/templates/matrix/transpose.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	if (gidx < {{ i_lens[0] }}u) {

--- a/wonnx/templates/pool/aggregate.wgsl
+++ b/wonnx/templates/pool/aggregate.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{% if (i_shape[0][1] % 4) == 0 %}

--- a/wonnx/templates/pool/conv.wgsl
+++ b/wonnx/templates/pool/conv.wgsl
@@ -1,26 +1,26 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Array;
 
 {%- if i_lens | length == 3 -%} // Bias
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_2: Array;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: Array;
 
 {%- else -%}
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: Array;
 
 {%- endif %}
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	if (gidx < {{ o_lens[0] }}u) {
 		let batch = gidx / {{ o_chunks[0][0] }}u; 

--- a/wonnx/templates/pool/conv_kernel_1.wgsl
+++ b/wonnx/templates/pool/conv_kernel_1.wgsl
@@ -1,27 +1,27 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: ArrayMatrix;
 
 {%- if i_lens | length == 3 -%} // Bias
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_2: ArrayVector;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: Array;
 
 {%- else -%}
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: Array;
 
 {%- endif %}
 
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	if (gidx < {{ o_lens[0]/4 }}u) {
 		let batch = gidx / {{ o_chunks[0][0] / 4 }}u; 

--- a/wonnx/templates/pool/conv_kernel_3.wgsl
+++ b/wonnx/templates/pool/conv_kernel_3.wgsl
@@ -1,26 +1,26 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: ArrayMatrix3;
 
 {%- if i_lens | length == 3 -%} // Bias
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_2: ArrayVector;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: Array;
 
 {%- else -%}
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: Array;
 
 {%- endif %}
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	if (gidx < {{ o_lens[0]/4 }}u) {
 		let batch = gidx / {{ o_chunks[0][0] / 4 }}u; 

--- a/wonnx/templates/pool/reduce.wgsl
+++ b/wonnx/templates/pool/reduce.wgsl
@@ -1,13 +1,13 @@
 {% include "structs.wgsl" %}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@stage(compute) @workgroup_size({{ workgroup_size_x }}, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{# We will be invoked once for each scalar in the output (output_0.data[gidx]) which represents one reduce operation.

--- a/wonnx/templates/structs.wgsl
+++ b/wonnx/templates/structs.wgsl
@@ -11,18 +11,18 @@ type Mat4x4 = mat4x4<{{ scalar_type }}>;
 type Mat4x3 = mat4x3<{{ scalar_type }}>;
 
 struct Array {
-	data: [[stride({{ scalar_stride }})]] array<Scalar>;
+	data: array<Scalar>,
 };
 
 struct ArrayVector {
-	data: [[stride({{ vec4_stride }})]] array<Vec4>;
+	data: array<Vec4>,
 };
 
 struct ArrayMatrix {
-	data: [[stride({{ mat4x4_stride }})]] array<Mat4x4>;
+	data: array<Mat4x4>,
 };
 
 struct ArrayMatrix3 {
-	data: [[stride({{ mat3x3_stride }})]] array<Mat3x3>;
+	data: array<Mat3x3>,
 };
 


### PR DESCRIPTION
First go at #56 (part of an attempt to fix WASM demo that appears to have stopped working in recent browser versions..).

This works when you change the wgpu dependency to `wgpu = { git="https://github.com/gfx-rs/wgpu.git" }`. This can be merged after wgpu releases 0.13.0 and we change our wgpu dependency to that version.