### PR TITLE
feat: add a way to only partially execute a model by manually specifying output names

### DIFF
--- a/wonnx-cli/src/gpu.rs
+++ b/wonnx-cli/src/gpu.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use wonnx::onnx::ModelProto;
+use wonnx::SessionOptions;
 
 use async_trait::async_trait;
 use wonnx::utils::OutputTensor;
@@ -14,9 +15,14 @@ pub struct GPUInferer {
 }
 
 impl GPUInferer {
-    pub async fn new(model_path: &str) -> Result<GPUInferer, NNXError> {
+    pub async fn new(
+        model_path: &str,
+        outputs: Option<Vec<String>>,
+    ) -> Result<GPUInferer, NNXError> {
+        let session_opts = SessionOptions { outputs };
+
         Ok(GPUInferer {
-            session: wonnx::Session::from_path(model_path).await?,
+            session: wonnx::Session::from_path_with_options(model_path, &session_opts).await?,
         })
     }
 }

--- a/wonnx-cli/src/gpu.rs
+++ b/wonnx-cli/src/gpu.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use wonnx::onnx::ModelProto;
-use wonnx::SessionOptions;
+use wonnx::SessionConfig;
 
 use async_trait::async_trait;
 use wonnx::utils::OutputTensor;
@@ -19,10 +19,10 @@ impl GPUInferer {
         model_path: &str,
         outputs: Option<Vec<String>>,
     ) -> Result<GPUInferer, NNXError> {
-        let session_opts = SessionOptions { outputs };
+        let session_config = SessionConfig::new().with_outputs(outputs);
 
         Ok(GPUInferer {
-            session: wonnx::Session::from_path_with_options(model_path, &session_opts).await?,
+            session: wonnx::Session::from_path_with_config(model_path, &session_config).await?,
         })
     }
 }

--- a/wonnx-cli/src/types.rs
+++ b/wonnx-cli/src/types.rs
@@ -115,6 +115,10 @@ pub struct InferOptions {
     #[structopt(long)]
     pub output_name: Option<String>,
 
+    /// Whether to attempt to only partially execute the model for the specified output
+    #[structopt(long)]
+    pub partial: bool,
+
     /// Vocab file for text encoding
     #[structopt(
         long = "vocab",

--- a/wonnx/src/lib.rs
+++ b/wonnx/src/lib.rs
@@ -89,6 +89,7 @@ pub enum SessionError {
     OptimizerError(#[from] OptimizerError),
 }
 
+#[non_exhaustive]
 pub struct SessionOptions {
     /// When set, only the specified outputs will be calculated, and nodes that are not inputs to these outputs may not be processed
     pub outputs: Option<Vec<String>>,
@@ -97,6 +98,11 @@ pub struct SessionOptions {
 impl SessionOptions {
     pub fn new() -> Self {
         Self { outputs: None }
+    }
+
+    pub fn with_outputs(mut self, outputs: Option<Vec<String>>) -> Self {
+        self.outputs = outputs;
+        self
     }
 }
 

--- a/wonnx/src/lib.rs
+++ b/wonnx/src/lib.rs
@@ -37,9 +37,7 @@ pub enum WonnxError {
     TypeError(#[from] DataTypeError),
 }
 
-/// Creates a new session connected to the GPU.
-///
-/// Generate a session that will translate the onnx format into WGSL instructions.
+/// An inference [session](Session) represents a model that is loaded and ready to perform inference on the GPU.
 ///
 /// # Examples
 ///
@@ -89,6 +87,7 @@ pub enum SessionError {
     OptimizerError(#[from] OptimizerError),
 }
 
+/// Provides optional configuration when creating an inference [Session].
 #[non_exhaustive]
 pub struct SessionOptions {
     /// When set, only the specified outputs will be calculated, and nodes that are not inputs to these outputs may not be processed
@@ -96,10 +95,12 @@ pub struct SessionOptions {
 }
 
 impl SessionOptions {
+    /// Creates a new [SessionOptions] struct with the default options set.
     pub fn new() -> Self {
         Self { outputs: None }
     }
 
+    /// Sets [`SessionOptions::outputs`] to the specified value and returns [Self].
     pub fn with_outputs(mut self, outputs: Option<Vec<String>>) -> Self {
         self.outputs = outputs;
         self
@@ -113,13 +114,13 @@ impl Default for SessionOptions {
 }
 
 impl Session {
-    // Read an ONNX model from a path and create a session.
+    // Read an ONNX model from a path and create a session, using default [session options](SessionOptions).
     pub async fn from_path<P: AsRef<Path>>(path: P) -> Result<Session, SessionError> {
         let model = onnx::ModelProto::parse_from_bytes(&std::fs::read(path)?)?;
         Session::from_model(model).await
     }
 
-    // Read an ONNX model from a path and create a session.
+    // Read an ONNX model from a path and create a session using the specified [session options](SessionOptions).
     pub async fn from_path_with_options<P: AsRef<Path>>(
         path: P,
         options: &SessionOptions,
@@ -128,13 +129,13 @@ impl Session {
         Session::from_model_with_options(model, options).await
     }
 
-    /// Read an ONNX model from bytes and create a session
+    /// Read an ONNX model from bytes and create a session, using default [session options](SessionOptions).
     pub async fn from_bytes(bytes: &[u8]) -> Result<Session, SessionError> {
         let model = onnx::ModelProto::parse_from_bytes(bytes)?;
         Session::from_model(model).await
     }
 
-    /// Read an ONNX model from bytes and create a session with the specified options
+    /// Read an ONNX model from bytes and create a session with the specified [session options](SessionOptions).
     pub async fn from_bytes_with_options(
         bytes: &[u8],
         options: &SessionOptions,
@@ -143,6 +144,7 @@ impl Session {
         Session::from_model_with_options(model, options).await
     }
 
+    /// Create a session using the provided [`onnx::ModelProto`] and [session options](SessionOptions).
     pub async fn from_model_with_options(
         model: onnx::ModelProto,
         options: &SessionOptions,
@@ -184,7 +186,7 @@ impl Session {
         Ok(Session { gpu_model })
     }
 
-    // Create a Session given an ONNX model.
+    /// Create a Session given an ONNX model, using default [session options](SessionOptions).
     pub async fn from_model(model: onnx::ModelProto) -> Result<Session, SessionError> {
         Self::from_model_with_options(model, &SessionOptions::new()).await
     }


### PR DESCRIPTION
Currently, it is only possible to construct an inference session that infers all of a model's outputs. This is not always desired (e.g. some outputs may be unused). For debugging purposes it may be useful to be able to calculate the output of a specific (intermediate) node.

This patch allows users to optionally specify a set of output names. When specified, only those outputs will be calculated and returned. Due to the way our IR is constructed, this also means that intermediate nodes that are not necessary to calculate the specified outputs will not be processed.

This adds `Session::from_{path|bytes|model}_with_options` and a `SessionOptions` struct. We can add more options to this struct in the future (e.g. GPU selection and such). Users should probably always add in a `..Default::defaults()` but I am not sure we can enforce this. We might also use a builder pattern for this. I left the old methods (`Session::from_{path|bytes|model}`) in place.

The CLI by default returns a single output (the first or the one specified by `--output-name`). It is useful to retain the 'fully calculate a model' capability, so I added a `--partial` flags that (combined with `--output_name`) will lead to partial execution up to the specified output only (in the future `--partial` could be made the default).