### PR TITLE
tests: use weaker comparison in test_pow because WGSL's pow(x,y) appears very imprecise

### DIFF
--- a/wonnx/tests/arithmetic.rs
+++ b/wonnx/tests/arithmetic.rs
@@ -1,3 +1,4 @@
+use approx::assert_abs_diff_eq;
 use std::{collections::HashMap, convert::TryInto};
 use wonnx::{
     onnx::TensorProto_DataType,
@@ -115,6 +116,13 @@ fn test_int64_initializers() {
     assert_eq!(result["Z"], OutputTensor::I64(sum))
 }
 
+pub fn assert_eq_vector_weak(xs: &[f32], ys: &[f32]) {
+    assert_eq!(xs.len(), ys.len());
+    for i in 0..xs.len() {
+        assert_abs_diff_eq!(xs[i], ys[i], epsilon = 0.5);
+    }
+}
+
 #[test]
 fn test_pow() {
     let n: usize = 16;
@@ -146,5 +154,6 @@ fn test_pow() {
         14.0, 224.99994, 4096.0,
     ];
 
-    common::assert_eq_vector((&result["Z"]).try_into().unwrap(), expected.as_slice());
+    // The pow(x,y) function in WGSL appears to be rather imprecise. Therefore we use a weaker comparison here (for now).
+    assert_eq_vector_weak((&result["Z"]).try_into().unwrap(), expected.as_slice());
 }


### PR DESCRIPTION
As discussed in #87 