### PR TITLE
ux: show friendly error message in CLI instead of debug one

### DIFF
--- a/wonnx-cli/src/main.rs
+++ b/wonnx-cli/src/main.rs
@@ -333,6 +333,12 @@ impl Backend {
     }
 }
 
-fn main() -> Result<(), NNXError> {
-    pollster::block_on(run())
+fn main() -> Result<(), std::io::Error> {
+    std::process::exit(match pollster::block_on(run()) {
+        Ok(_) => 0,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            1
+        }
+    });
 }


### PR DESCRIPTION
This PR makes the CLI display friendly error messages:

````
Error: backend execution error: IR error: issue with data types: parametrized dimensions are not supported (this may be solved by running onnx-simplifier on the model first)
````

instead of the `Debug` ones:

````
Error: BackendExecutionFailed(GpuError(CompileError(InvalidInputShape { input_index: 1, input_shape: Shape { dims: [2, 768], data_type: F32 } })))
````