### PR TITLE
Use only primary wgpu backends by default

### DIFF
--- a/wonnx/src/resource.rs
+++ b/wonnx/src/resource.rs
@@ -2,8 +2,8 @@ use wgpu::{util::DeviceExt, BufferUsages};
 
 // Get a device and a queue, honoring WGPU_ADAPTER_NAME and WGPU_BACKEND environment variables
 pub async fn request_device_queue() -> (wgpu::Device, wgpu::Queue) {
-    let instance = wgpu::Instance::new(wgpu::Backends::all());
-    let backends = wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all);
+    let backends = wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::PRIMARY);
+    let instance = wgpu::Instance::new(backends);
     let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, backends, None)
         .await
         .expect("No GPU found given preference");


### PR DESCRIPTION
Using `Backends::all()` enables unsupported backends such as OpenGL, which results in obscure errors at least on my Linux system.