### PR TITLE
Promote `debug_assert`s to normal `assert`s

### DIFF
--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -771,7 +771,12 @@ pub fn compile(
         op @ ("MaxPool" | "AveragePool" | "Conv" | "ConvRelu" | "ConvLeakyRelu" | "ConvMish"
         | "GlobalAveragePool") => {
             // TODO: Conv only support NxCxHxW for the moment.
-            assert!(input_shapes[0].rank() == 4);
+            if input_shapes[0].rank() != 4 {
+                return Err(CompileError::InvalidInputShape {
+                    input_index: 0,
+                    input_shape: input_shapes[0].clone(),
+                });
+            }
 
             // GlobalAveragePool is equivalent to AveragePool, with the kernel shape set to the size of the input tensor
             // See https://github.com/onnx/onnx/blob/main/docs/Operators.md#globalaveragepool

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -771,7 +771,7 @@ pub fn compile(
         op @ ("MaxPool" | "AveragePool" | "Conv" | "ConvRelu" | "ConvLeakyRelu" | "ConvMish"
         | "GlobalAveragePool") => {
             // TODO: Conv only support NxCxHxW for the moment.
-            debug_assert!(input_shapes[0].rank() == 4);
+            assert!(input_shapes[0].rank() == 4);
 
             // GlobalAveragePool is equivalent to AveragePool, with the kernel shape set to the size of the input tensor
             // See https://github.com/onnx/onnx/blob/main/docs/Operators.md#globalaveragepool

--- a/wonnx/src/utils.rs
+++ b/wonnx/src/utils.rs
@@ -438,7 +438,7 @@ pub fn tensor_of_type(
 
 pub fn initializer(name: &str, data: Vec<f32>, dimensions: Vec<i64>) -> onnx::TensorProto {
     let mut initializer = crate::onnx::TensorProto::new();
-    debug_assert_eq!(
+    assert_eq!(
         dimensions.iter().cloned().product::<i64>() as usize,
         data.len()
     );
@@ -451,7 +451,7 @@ pub fn initializer(name: &str, data: Vec<f32>, dimensions: Vec<i64>) -> onnx::Te
 
 pub fn initializer_int64(name: &str, data: Vec<i64>, dimensions: Vec<i64>) -> onnx::TensorProto {
     let mut initializer = crate::onnx::TensorProto::new();
-    debug_assert_eq!(
+    assert_eq!(
         dimensions.iter().cloned().product::<i64>() as usize,
         data.len()
     );


### PR DESCRIPTION
As far as I can tell, none of these asserts are in performance-sensitive code, so it makes sense to have them always checked to ensure that no invariants are violated.