### PR TITLE
fix: prevent tanh from producing NaN values

### DIFF
--- a/wonnx/templates/endomorphism/map.wgsl
+++ b/wonnx/templates/endomorphism/map.wgsl
@@ -12,7 +12,13 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	{% if op_type == "Reciprocal" %}
 		let one = Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1));
 		output_0.data[gidx] = one / (input_0.data[gidx]);
-
+	{% elif op_type == "Tanh" %}
+		{# Tanh will produce NaNs when fed with inputs that are much larger than +10.0 or smaller than -10.0. As the output
+		for these inputs converges to 1.0 and -1.0 respectively, we clamp the inputs first. #}
+		let one = Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1));
+		let boundary = one * Scalar(10);
+		let intermediate = max(-boundary, min(boundary, input_0.data[gidx]));
+		output_0.data[gidx] = tanh(intermediate);
 	{% else %}
 		output_0.data[gidx] = {{ op_type | lower }}(input_0.data[gidx]);
 


### PR DESCRIPTION
The `tanh` function in WGSL apparently produces NaN values for large (absolute) inputs. As `tanh` basically converges to 1, this PR clamps the input values to `tanh` to be between [-10, 10].

````python
>>> import math
>>> math.tanh(10)
0.9999999958776927
>>> math.tanh(-10)
-0.9999999958776927
````