### PR TITLE
Fix: split operator does not take all elements into account

### DIFF
--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -1235,7 +1235,7 @@ pub fn compile(
             NodeTemplate {
                 scalar_type: agreed_type(&input_shapes[0..1], &output_shapes[0..1])?,
                 template: "matrix/split.wgsl",
-                threads: (ceil(output_lengths[0], 256) as u32, 1, 1),
+                threads: (ceil(input_lengths[0], 256) as u32, 1, 1),
             }
         }
         "Pad" => {

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -1233,7 +1233,7 @@ pub fn compile(
             context.insert("split", &split);
 
             NodeTemplate {
-                scalar_type: agreed_type(&input_shapes[0..1], &output_shapes[0..1])?,
+                scalar_type: agreed_type(&input_shapes[0..1], output_shapes)?,
                 template: "matrix/split.wgsl",
                 threads: (ceil(input_lengths[0], 256) as u32, 1, 1),
             }


### PR DESCRIPTION
When doing a split of a `2x1x256` tensor into two `1x1x256` tensors I found that the second tensor was all zeroes. This was caused by the fact that the Split shader would only be started with `output_lengths[0]/256` workgroups (and hence would only copy 256 values from input) whereas there are in fact 512 values (so n_threads should be 2). This PR changes the number of threads to `input_lengths[0]/256` which makes this work properly.

Note we can't enable the ONNX backend tests for this op because those use dynamic inputs for the `split` input (which we don't support at the moment). The `test_split` case doesn't catch this error as the number of elements is below 256, and we simply start one thread (with workgroup size 256) in that case.