### PR TITLE
Feature/qa improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,10 +3876,12 @@ dependencies = [
 name = "wonnx-preprocessing"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "image",
  "log",
  "ndarray",
  "protobuf",
+ "serde_json",
  "thiserror",
  "tokenizers",
  "tract-onnx",

--- a/wonnx-cli/Cargo.toml
+++ b/wonnx-cli/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 [dependencies]
 async-trait = "0.1.53"
 env_logger = "0.9.0"
-
 log = "0.4.17"
 ndarray = "0.15.4"
 pollster = "0.2.5"

--- a/wonnx-cli/src/main.rs
+++ b/wonnx-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use structopt::StructOpt;
 use wonnx::onnx::ModelProto;
 use wonnx::utils::{OutputTensor, Shape};
-use wonnx_preprocessing::text::{get_lines, BertEncodedText};
+use wonnx_preprocessing::text::{get_lines, EncodedText};
 use wonnx_preprocessing::Tensor;
 
 mod gpu;
@@ -71,7 +71,7 @@ async fn run() -> Result<(), NNXError> {
 
 fn print_qa_output(
     infer_opt: &InferOptions,
-    qa_encoding: &BertEncodedText,
+    qa_encoding: &EncodedText,
     mut outputs: HashMap<String, OutputTensor>,
 ) -> Result<(), NNXError> {
     let start_output: Vec<f32> = outputs
@@ -86,11 +86,13 @@ fn print_qa_output(
 
     println!(
         "{}",
-        qa_encoding.get_answer(
-            &start_output,
-            &end_output,
-            infer_opt.context.as_ref().unwrap()
-        )
+        qa_encoding
+            .get_answer(
+                &start_output,
+                &end_output,
+                infer_opt.context.as_ref().unwrap()
+            )
+            .text
     );
     Ok(())
 }

--- a/wonnx-cli/src/main.rs
+++ b/wonnx-cli/src/main.rs
@@ -84,49 +84,7 @@ fn print_qa_output(
         .ok_or_else(|| NNXError::OutputNotFound(infer_opt.qa_answer_start.to_string()))?
         .try_into()?;
 
-    let mut best_start_logit = f32::MIN;
-    let mut best_start_idx: usize = 0;
-
-    let input_tokens = qa_encoding.encoding.get_tokens();
-
-    for (start_idx, start_logit) in start_output.iter().enumerate() {
-        if start_idx > input_tokens.len() - 1 {
-            break;
-        }
-        match input_tokens[start_idx].as_str() {
-            "[CLS]" | "[SEP]" | "[PAD]" => continue,
-            _ => {}
-        }
-
-        if *start_logit > best_start_logit {
-            best_start_logit = *start_logit;
-            best_start_idx = start_idx;
-        }
-    }
-
-    // Find matching end
-    let mut best_end_logit = f32::MIN;
-    let mut best_end_idx = best_start_idx;
-    for (end_idx, end_logit) in end_output[best_start_idx..].iter().enumerate() {
-        if (end_idx + best_start_idx) > input_tokens.len() - 1 {
-            break;
-        }
-
-        match input_tokens[end_idx + best_start_idx].as_str() {
-            "[CLS]" | "[SEP]" | "[PAD]" => continue,
-            _ => {}
-        }
-
-        if *end_logit > best_end_logit {
-            best_end_logit = *end_logit;
-            best_end_idx = end_idx + best_start_idx;
-        }
-    }
-
-    log::debug!("Start index: {} ({})", best_start_idx, best_start_logit);
-    log::debug!("End index: {} ({})", best_end_idx, best_end_logit);
-    let tokens = &qa_encoding.encoding.get_tokens()[best_start_idx..=best_end_idx];
-    println!("{}", tokens.join(" "));
+    println!("{}", qa_encoding.get_answer(&start_output, &end_output));
     Ok(())
 }
 

--- a/wonnx-cli/src/main.rs
+++ b/wonnx-cli/src/main.rs
@@ -84,7 +84,14 @@ fn print_qa_output(
         .ok_or_else(|| NNXError::OutputNotFound(infer_opt.qa_answer_start.to_string()))?
         .try_into()?;
 
-    println!("{}", qa_encoding.get_answer(&start_output, &end_output));
+    println!(
+        "{}",
+        qa_encoding.get_answer(
+            &start_output,
+            &end_output,
+            infer_opt.context.as_ref().unwrap()
+        )
+    );
     Ok(())
 }
 

--- a/wonnx-cli/src/types.rs
+++ b/wonnx-cli/src/types.rs
@@ -7,7 +7,7 @@ use wonnx::{
     SessionError, WonnxError,
 };
 use wonnx_preprocessing::{
-    text::{BertEncodedText, PreprocessingError},
+    text::{EncodedText, PreprocessingError},
     Tensor,
 };
 
@@ -64,6 +64,9 @@ pub enum NNXError {
 
     #[error("tensor error: {0}")]
     TensorConversionError(#[from] TensorConversionError),
+
+    #[error("I/O error: {0}")]
+    IOError(#[from] std::io::Error),
 }
 
 impl FromStr for Backend {
@@ -118,13 +121,13 @@ pub struct InferOptions {
     #[structopt(long)]
     pub output_name: Vec<String>,
 
-    /// Vocab file for text encoding
+    /// Tokenizer config file (JSON) for text encoding
     #[structopt(
-        long = "vocab",
+        long = "tokenizer",
         parse(from_os_str),
-        default_value = "./data/models/bertsquad-vocab.txt"
+        default_value = "./data/models/bertsquad-tokenizer.json"
     )]
-    pub vocab: PathBuf,
+    pub tokenizer: PathBuf,
 
     /// Sets question for question-answering
     #[structopt(short = "q", long = "question")]
@@ -230,5 +233,5 @@ pub trait Inferer {
 pub struct InferenceInput {
     pub inputs: HashMap<String, Tensor>,
     pub input_shapes: HashMap<String, Shape>,
-    pub qa_encoding: Option<BertEncodedText>,
+    pub qa_encoding: Option<EncodedText>,
 }

--- a/wonnx-cli/src/types.rs
+++ b/wonnx-cli/src/types.rs
@@ -125,7 +125,7 @@ pub struct InferOptions {
     #[structopt(
         long = "tokenizer",
         parse(from_os_str),
-        default_value = "./data/models/bertsquad-tokenizer.json"
+        default_value = "./tokenizer.json"
     )]
     pub tokenizer: PathBuf,
 

--- a/wonnx-cli/src/utils.rs
+++ b/wonnx-cli/src/utils.rs
@@ -166,8 +166,8 @@ impl InferenceInput {
                 segment_length
             );
 
-            let bert_tokenizer = TextTokenizer::from_config(&infer_opt.tokenizer)?;
-            let mut encoding = bert_tokenizer.tokenize_question_answer(question, context)?;
+            let tokenizer = TextTokenizer::from_config(&infer_opt.tokenizer)?;
+            let mut encoding = tokenizer.tokenize_question_answer(question, context)?;
 
             let first_encoding = encoding.remove(0);
 
@@ -210,14 +210,14 @@ impl InferenceInput {
 
         // Process text inputs
         if !infer_opt.text.is_empty() || !infer_opt.text_mask.is_empty() {
-            let bert_tokenizer = TextTokenizer::from_config(&infer_opt.tokenizer)?;
+            let tokenizer = TextTokenizer::from_config(&infer_opt.tokenizer)?;
 
             // Tokenized text input
             for (text_input_name, text) in &infer_opt.text {
                 let text_input_shape = model
                     .get_input_shape(text_input_name)?
                     .ok_or_else(|| NNXError::InputNotFound(text_input_name.clone()))?;
-                let input = bert_tokenizer.get_input_for(text, &text_input_shape)?;
+                let input = tokenizer.get_input_for(text, &text_input_shape)?;
                 inputs.insert(text_input_name.clone(), input);
                 input_shapes.insert(text_input_name.clone(), text_input_shape);
             }
@@ -227,7 +227,7 @@ impl InferenceInput {
                 let text_input_shape = model
                     .get_input_shape(text_input_name)?
                     .ok_or_else(|| NNXError::InputNotFound(text_input_name.clone()))?;
-                let input = bert_tokenizer.get_mask_input_for(text, &text_input_shape)?;
+                let input = tokenizer.get_mask_input_for(text, &text_input_shape)?;
                 inputs.insert(text_input_name.clone(), input);
                 input_shapes.insert(text_input_name.clone(), text_input_shape);
             }

--- a/wonnx-preprocessing/Cargo.toml
+++ b/wonnx-preprocessing/Cargo.toml
@@ -13,3 +13,7 @@ tokenizers = "0.11.3"
 tract-onnx = { version = "0.16.7", optional = true }
 wgpu = "0.12.0"
 wonnx = { path = "../wonnx" }
+serde_json = "^1.0"
+
+[dev-dependencies]
+env_logger = "0.9.0"

--- a/wonnx-preprocessing/src/text.rs
+++ b/wonnx-preprocessing/src/text.rs
@@ -179,7 +179,7 @@ impl BertEncodedText {
             .collect()
     }
 
-    pub fn get_answer(&self, start_output: &[f32], end_output: &[f32]) -> String {
+    pub fn get_answer(&self, start_output: &[f32], end_output: &[f32], context: &str) -> String {
         let mut best_start_logit = f32::MIN;
         let mut best_start_idx: usize = 0;
 
@@ -219,10 +219,20 @@ impl BertEncodedText {
             }
         }
 
-        log::debug!("Start index: {} ({})", best_start_idx, best_start_logit);
-        log::debug!("End index: {} ({})", best_end_idx, best_end_logit);
-        let tokens = &self.encoding.get_tokens()[best_start_idx..=best_end_idx];
-        tokens.join(" ")
+        log::debug!("start index: {} ({})", best_start_idx, best_start_logit);
+        log::debug!("end index: {} ({})", best_end_idx, best_end_logit);
+
+        let chars: Vec<char> = context.chars().collect();
+        let offsets = self.encoding.get_offsets();
+        log::debug!("offsets: {:?}", &offsets[best_start_idx..=best_end_idx]);
+
+        let answer = offsets[best_start_idx..=best_end_idx]
+            .iter()
+            .map(|offset| chars[offset.0..offset.1].iter().collect::<String>())
+            .collect::<Vec<String>>()
+            .join(" ");
+
+        answer
     }
 }
 

--- a/wonnx-preprocessing/src/text.rs
+++ b/wonnx-preprocessing/src/text.rs
@@ -134,14 +134,16 @@ impl EncodedText {
         let mut best_start_idx: usize = 0;
 
         let input_tokens = self.encoding.get_tokens();
+        let special_tokens_mask = self.encoding.get_special_tokens_mask();
 
         for (start_idx, start_logit) in start_output.iter().enumerate() {
             if start_idx > input_tokens.len() - 1 {
                 break;
             }
-            match input_tokens[start_idx].as_str() {
-                "[CLS]" | "[SEP]" | "[PAD]" => continue,
-                _ => {}
+
+            // Skip special tokens such as [CLS], [SEP], [PAD]
+            if special_tokens_mask[start_idx] == 1 {
+                continue;
             }
 
             if *start_logit > best_start_logit {
@@ -158,9 +160,9 @@ impl EncodedText {
                 break;
             }
 
-            match input_tokens[end_idx + best_start_idx].as_str() {
-                "[CLS]" | "[SEP]" | "[PAD]" => continue,
-                _ => {}
+            // Skip special tokens such as [CLS], [SEP], [PAD]
+            if special_tokens_mask[end_idx + best_start_idx] == 1 {
+                continue;
             }
 
             if *end_logit > best_end_logit {

--- a/wonnx-preprocessing/src/text.rs
+++ b/wonnx-preprocessing/src/text.rs
@@ -3,14 +3,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use thiserror::Error;
-use tokenizers::models::wordpiece::WordPieceBuilder;
-use tokenizers::normalizers::BertNormalizer;
-use tokenizers::pre_tokenizers::bert::BertPreTokenizer;
-use tokenizers::processors::bert::BertProcessing;
-use tokenizers::utils::padding::{PaddingDirection::Right, PaddingParams, PaddingStrategy::Fixed};
-use tokenizers::utils::truncation::TruncationParams;
-use tokenizers::utils::truncation::TruncationStrategy::LongestFirst;
-use tokenizers::{AddedToken, EncodeInput, Encoding, InputSequence, Tokenizer};
+use tokenizers::{EncodeInput, Encoding, InputSequence, Tokenizer};
 use wonnx::utils::Shape;
 
 use crate::Tensor;
@@ -21,103 +14,53 @@ pub enum PreprocessingError {
     TextTokenizationError(#[from] Box<dyn std::error::Error + Sync + Send>),
 }
 
-pub struct BertTokenizer {
+pub struct TextTokenizer {
     pub tokenizer: Tokenizer,
 }
 
-pub struct BertEncodedText {
+#[derive(Debug)]
+pub struct EncodedText {
     pub encoding: Encoding,
 }
 
-impl BertTokenizer {
-    pub fn new(vocab_path: &Path) -> BertTokenizer {
-        let wp_builder = WordPieceBuilder::new()
-            .files(vocab_path.as_os_str().to_string_lossy().to_string())
-            .continuing_subword_prefix("##".into())
-            .max_input_chars_per_word(100)
-            .unk_token("[UNK]".into())
-            .build()
-            .unwrap();
+impl TextTokenizer {
+    pub fn new(tokenizer: Tokenizer) -> TextTokenizer {
+        TextTokenizer { tokenizer }
+    }
 
-        let mut tokenizer = Tokenizer::new(wp_builder);
-        tokenizer.with_padding(Some(PaddingParams {
-            strategy: Fixed(60),
-            direction: Right,
-            pad_id: 0,
-            pad_type_id: 0,
-            pad_token: "[PAD]".into(),
-            pad_to_multiple_of: None,
-        }));
-        tokenizer.with_truncation(Some(TruncationParams {
-            max_length: 60,
-            strategy: LongestFirst,
-            stride: 0,
-            ..Default::default()
-        }));
-        tokenizer.with_pre_tokenizer(BertPreTokenizer);
-        tokenizer.with_post_processor(BertProcessing::new(
-            ("[SEP]".into(), 102),
-            ("[CLS]".into(), 101),
-        ));
-        tokenizer.with_normalizer(BertNormalizer::new(true, true, Some(false), false));
-        tokenizer.add_special_tokens(&[
-            AddedToken {
-                content: "[PAD]".into(),
-                single_word: false,
-                lstrip: false,
-                rstrip: false,
-                normalized: false, //?
-                ..Default::default()
-            },
-            AddedToken {
-                content: "[CLS]".into(),
-                single_word: false,
-                lstrip: false,
-                rstrip: false,
-                normalized: false, //?
-                ..Default::default()
-            },
-            AddedToken {
-                content: "[SEP]".into(),
-                single_word: false,
-                lstrip: false,
-                rstrip: false,
-                normalized: false, //?
-                ..Default::default()
-            },
-            AddedToken {
-                content: "[MASK]".into(),
-                single_word: false,
-                lstrip: false,
-                rstrip: false,
-                normalized: false, //?
-                ..Default::default()
-            },
-        ]);
-
-        BertTokenizer { tokenizer }
+    pub fn from_config<P: AsRef<Path>>(path: P) -> Result<TextTokenizer, std::io::Error> {
+        let tokenizer_config_file = File::open(path)?;
+        let tokenizer_config_reader = BufReader::new(tokenizer_config_file);
+        let tokenizer = serde_json::from_reader(tokenizer_config_reader)?;
+        Ok(TextTokenizer::new(tokenizer))
     }
 
     pub fn tokenize_question_answer(
         &self,
         question: &str,
         context: &str,
-    ) -> Result<BertEncodedText, PreprocessingError> {
-        Ok(BertEncodedText {
-            encoding: self
-                .tokenizer
-                .encode(
-                    EncodeInput::Dual(
-                        InputSequence::Raw(Cow::from(question)),
-                        InputSequence::Raw(Cow::from(context)),
-                    ),
-                    true,
-                )
-                .map_err(PreprocessingError::TextTokenizationError)?,
-        })
+    ) -> Result<Vec<EncodedText>, PreprocessingError> {
+        let mut encoding = self
+            .tokenizer
+            .encode(
+                EncodeInput::Dual(
+                    InputSequence::Raw(Cow::from(question)),
+                    InputSequence::Raw(Cow::from(context)),
+                ),
+                true,
+            )
+            .map_err(PreprocessingError::TextTokenizationError)?;
+
+        let mut overflowing = encoding.take_overflowing();
+        overflowing.insert(0, encoding);
+
+        Ok(overflowing
+            .into_iter()
+            .map(|x| EncodedText { encoding: x })
+            .collect())
     }
 
-    fn tokenize(&self, text: &str) -> Result<BertEncodedText, PreprocessingError> {
+    fn tokenize(&self, text: &str) -> Result<EncodedText, PreprocessingError> {
         let encoding = self
             .tokenizer
             .encode(
@@ -125,10 +68,10 @@ impl BertTokenizer {
                 true,
             )
             .map_err(PreprocessingError::TextTokenizationError)?;
-        Ok(BertEncodedText { encoding })
+        Ok(EncodedText { encoding })
     }
 
-    pub fn decode(&self, encoding: &BertEncodedText) -> Result<String, PreprocessingError> {
+    pub fn decode(&self, encoding: &EncodedText) -> Result<String, PreprocessingError> {
         let ids = encoding.get_tokens().iter().map(|x| *x as u32).collect();
         self.tokenizer
             .decode(ids, true)
@@ -158,7 +101,14 @@ impl BertTokenizer {
     }
 }
 
-impl BertEncodedText {
+#[derive(Debug)]
+pub struct Answer {
+    pub text: String,
+    pub tokens: Vec<String>,
+    pub score: f32,
+}
+
+impl EncodedText {
     pub fn get_mask(&self) -> Vec<i64> {
         self.encoding
             .get_attention_mask()
@@ -179,7 +129,7 @@ impl BertEncodedText {
             .collect()
     }
 
-    pub fn get_answer(&self, start_output: &[f32], end_output: &[f32], context: &str) -> String {
+    pub fn get_answer(&self, start_output: &[f32], end_output: &[f32], context: &str) -> Answer {
         let mut best_start_logit = f32::MIN;
         let mut best_start_idx: usize = 0;
 
@@ -226,13 +176,26 @@ impl BertEncodedText {
         let offsets = self.encoding.get_offsets();
         log::debug!("offsets: {:?}", &offsets[best_start_idx..=best_end_idx]);
 
-        let answer = offsets[best_start_idx..=best_end_idx]
-            .iter()
-            .map(|offset| chars[offset.0..offset.1].iter().collect::<String>())
-            .collect::<Vec<String>>()
-            .join(" ");
+        let answer_tokens: Vec<String> =
+            self.encoding.get_tokens()[best_start_idx..best_end_idx].to_vec();
 
-        answer
+        let min_offset = offsets[best_start_idx..=best_end_idx]
+            .iter()
+            .map(|o| o.0)
+            .min()
+            .unwrap();
+        let max_offset = offsets[best_start_idx..=best_end_idx]
+            .iter()
+            .map(|o| o.1)
+            .max()
+            .unwrap();
+        let answer = chars[min_offset..max_offset].iter().collect::<String>();
+
+        Answer {
+            text: answer,
+            tokens: answer_tokens,
+            score: best_start_logit * best_end_logit,
+        }
     }
 }
 


### PR DESCRIPTION
This PR improves some things around working with Q/A models (primarily in the preprocessing crate and the CLI):

- Return the 'answer text' based on the original input context text
- Do not set a fixed BERT specific tokenizer, instead require user to load it from a config JSON (which appears to be the typical way to do it for e.g. Huggingface transformers as well)
- Support segmenting the input in case the context text is larger than the maximum sequence size