### PR TITLE
Fix/upgrade to wgpu 0.13.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUST_VERSION: 1.58
+  RUST_VERSION: 1.62
 
 # We distinguish the following kinds of builds:
 # - local: build for the same target as we compile on, and do local tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "once_cell",
  "version_check",
 ]
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "anymap2"
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -141,12 +141,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -242,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byte-tools"
@@ -254,9 +248,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
+checksum = "c53dfa917ec274df8ed3c572698f381a24eef2efba9492d797301b72b6db408a"
 
 [[package]]
 name = "byteorder"
@@ -458,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -479,33 +473,33 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
@@ -700,9 +694,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+checksum = "140206b78fb2bc3edbcfc9b5ccbd0b30699cfe8d348b8b31b330e47df5291a5a"
 
 [[package]]
 name = "educe"
@@ -718,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encode_unicode"
@@ -766,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "esaxx-rs"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4617b351b734e97a3dd32022a721471349aa3038d4132beee8568cdfa7e716"
+checksum = "1f748b253ceca9fed5f42f8b5ceb3851e93102199bc25b64b65369f76e5c0a35"
 dependencies = [
  "cc",
 ]
@@ -806,14 +800,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.13",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -834,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c03199d0c0ca54bc1ea90ac0d507274c28abcc4f691ae8b4eaa375087c76a"
+checksum = "1ceeb589a3157cac0ab8cc585feb749bd2cea5cb55a6ee802ad72d9fd38303da"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -975,22 +969,22 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "gif"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a7187e78088aead22ceedeee99779455b23fc231fe13ec443f99bb71694e5b"
+checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1004,9 +998,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1065,7 +1059,7 @@ checksum = "a538f217be4d405ff4719a283ca68323cc2384003eca5baaa87501e821c81dda"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1112,6 +1106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,9 +1137,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -1275,12 +1275,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -1433,19 +1433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7efd1d698db0759e6ef11a7cd44407407399a910c774dd804c64c032da7826ff"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,7 +1476,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
- "time 0.3.9",
+ "time 0.3.11",
 ]
 
 [[package]]
@@ -1515,7 +1502,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
- "time 0.3.9",
+ "time 0.3.11",
  "unicode-segmentation",
 ]
 
@@ -1636,18 +1623,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -1687,7 +1674,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -1719,17 +1706,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rawpointer",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -1769,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
 ]
@@ -1799,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -1876,9 +1852,9 @@ checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "onig"
-version = "6.3.1"
+version = "6.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ddfe2c93bb389eea6e6d713306880c7f6dcc99a75b659ce145d962c861b225"
+checksum = "1eb3502504c9c8b06634b38bfdda86a9a8cef6277f3dec4d8b17c115110dd2a3"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -1888,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.7.1"
+version = "69.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd3eee045c84695b53b20255bb7317063df090b68e18bfac0abb6c39cf7f33e"
+checksum = "8bf3fbc9b931b6c9af85d219c7943c274a6ad26cff7488a2210215edd5f49bf8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1936,9 +1912,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
 dependencies = [
  "autocfg",
  "cc",
@@ -1949,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2064,18 +2040,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2197,9 +2173,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2357,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -2423,7 +2399,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -2523,7 +2499,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "redox_syscall 0.2.13",
  "thiserror",
 ]
@@ -2568,11 +2544,11 @@ checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2595,6 +2571,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2608,7 +2585,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -2706,24 +2683,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2732,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
@@ -2793,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -2828,21 +2805,15 @@ dependencies = [
 
 [[package]]
 name = "spm_precompiled"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e3ef0f38d59930678abc6404a61c98831a413111bbb3f6fca47683043ea715"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
 dependencies = [
- "base64 0.12.3",
- "nom 5.1.2",
+ "base64",
+ "nom",
  "serde",
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2883,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2925,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3cac831b615c25bcef632d1cabf864fa05813baad3d526829db18eb70e8b58d"
+checksum = "7c9783d6ff395ae80cf17ed9a25360e7ba37742a79fa8fddabb073c5c7c8856d"
 dependencies = [
  "globwalk",
  "lazy_static",
@@ -3035,19 +3006,20 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa 1.0.2",
  "libc",
@@ -3111,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
  "bytes",
  "libc",
@@ -3138,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3152,47 +3124,35 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "tract-core"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7925e7077194b730cdc9a9a91c454bfc03991f14e34f0fecd0e327558c94e034"
+checksum = "bd08ded275f4a81ee620bc72e862584f87add152f29b556362d65e5fff44cdc3"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -3207,15 +3167,57 @@ dependencies = [
  "num-integer",
  "num-traits",
  "smallvec",
- "tract-data",
- "tract-linalg",
+ "tract-data 0.16.9",
+ "tract-linalg 0.16.9",
+]
+
+[[package]]
+name = "tract-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97e029047bf3a3679f28648fc90719574ea4b72267e15cc8ffa9ad6188d316"
+dependencies = [
+ "anyhow",
+ "bit-set",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "educe",
+ "lazy_static",
+ "log",
+ "maplit",
+ "ndarray",
+ "num-integer",
+ "num-traits",
+ "smallvec",
+ "tract-data 0.17.0",
+ "tract-linalg 0.17.0",
 ]
 
 [[package]]
 name = "tract-data"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be91babcd5c020498c2ad534d2810fdf285de13c1007d3853a5a86d87813e5b0"
+checksum = "1367afc745e4253af27787e143ed9f6aaad2c5c9e9b39f84dac7a0c60bd4c404"
+dependencies = [
+ "anyhow",
+ "educe",
+ "half",
+ "itertools 0.10.3",
+ "lazy_static",
+ "maplit",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
+name = "tract-data"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd1e09b9ec99cfd446db49dbfde76411f3ad98c8d57b02604a1ccf3189d6957"
 dependencies = [
  "anyhow",
  "educe",
@@ -3232,21 +3234,33 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2634afa31f55959a488f3cecf900fb9e9fa9ad6293091df99b14717bec8965a"
+checksum = "2500104634d4ec947a70f0a72b302eae4e76b10fe35bb6418c0512b578c08815"
 dependencies = [
  "derive-new",
  "educe",
  "log",
- "tract-core",
+ "tract-core 0.16.9",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6c2acc716340e2f55e3ebb641ccad71b25c7743064f8a405a165a9a6595954"
+dependencies = [
+ "derive-new",
+ "educe",
+ "log",
+ "tract-core 0.17.0",
 ]
 
 [[package]]
 name = "tract-linalg"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfc7107f3d3f0d493bb5cf9b0d4756a80b22c50a129586f9c6e559bcfc57ddf"
+checksum = "58813d7efae98c8f6208bf9c5adcbd14127efca82ad7cedba059489f4261a7e0"
 dependencies = [
  "cc",
  "derive-new",
@@ -3261,31 +3275,70 @@ dependencies = [
  "paste",
  "scan_fmt",
  "smallvec",
- "tract-data",
+ "tract-data 0.16.9",
+ "unicode-normalization",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-linalg"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa4dad2ea99f5900bd71168c504ba4b2821f2497856ed3b5c23652ec6f8da71"
+dependencies = [
+ "cc",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "educe",
+ "lazy_static",
+ "libc",
+ "liquid",
+ "log",
+ "num-traits",
+ "paste",
+ "scan_fmt",
+ "smallvec",
+ "tract-data 0.17.0",
  "unicode-normalization",
  "walkdir",
 ]
 
 [[package]]
 name = "tract-nnef"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1537175515d258ba9243e30bc6ef64edcba7c3c162a932b3bb13c71d8054510"
+checksum = "bb2b7add8484e5e383105f98bfaefd17634d02f5b68cd857bfbd00ee1c2d1bc4"
 dependencies = [
  "byteorder",
  "flate2",
  "log",
- "nom 7.1.1",
+ "nom",
  "tar",
- "tract-core",
+ "tract-core 0.16.9",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-nnef"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a480ea422995e30877afbd8fc434672937094df0999bdfc32ca59a555b22add7"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "log",
+ "nom",
+ "tar",
+ "tract-core 0.17.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tract-onnx"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c551b812161d3c916a2b6618e29637ef5823dafc69761aedf502bfe0ea3dd7ef"
+checksum = "6e3529be4ee7261e640ca96429f1d579c95478e82d8b70b22ab70680871dd896"
 dependencies = [
  "bytes",
  "derive-new",
@@ -3296,19 +3349,49 @@ dependencies = [
  "prost",
  "prost-build",
  "smallvec",
- "tract-hir",
- "tract-nnef",
- "tract-onnx-opl",
+ "tract-hir 0.16.9",
+ "tract-nnef 0.16.9",
+ "tract-onnx-opl 0.16.9",
+]
+
+[[package]]
+name = "tract-onnx"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff59cf937e7ec868bd86ec29248b2de4a7445e7656d7afcaf88743bffef34b45"
+dependencies = [
+ "bytes",
+ "derive-new",
+ "educe",
+ "log",
+ "mapr",
+ "num-integer",
+ "prost",
+ "prost-build",
+ "smallvec",
+ "tract-hir 0.17.0",
+ "tract-nnef 0.17.0",
+ "tract-onnx-opl 0.17.0",
 ]
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad3e60e7b331963de0d2156e7f88138f4e046b9d89745d752c56e33e6a789d6"
+checksum = "a15eb3c0efa63cceae51004b5b845bf92e828323b7fcde478c886d3c7d7a5a2e"
 dependencies = [
  "educe",
- "tract-nnef",
+ "tract-nnef 0.16.9",
+]
+
+[[package]]
+name = "tract-onnx-opl"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1553cf0c89a1c196326e60e7ec15546769d50f1763aca747855cd761b41c5d2d"
+dependencies = [
+ "educe",
+ "tract-nnef 0.17.0",
 ]
 
 [[package]]
@@ -3387,15 +3470,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -3507,9 +3590,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -3597,9 +3680,9 @@ checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4464b3f74729a25f42b1a0cd9e6a515d2f25001f3535a6cfaf35d34a4de3bab"
+checksum = "68b30cf2cba841a812f035c40c50f53eb9c56181192a9dd2c71b65e6a87a05ba"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -3611,9 +3694,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c5a6f82cc6093a321ca5fb3dc9327fe51675d477b3799b4a9375bac3b7b4c"
+checksum = "88ad594bf33e73cafcac2ae9062fc119d4f75f9c77e25022f91c9a64bd5b6463"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3859,7 +3942,7 @@ dependencies = [
  "protobuf",
  "structopt",
  "thiserror",
- "tract-onnx",
+ "tract-onnx 0.16.9",
  "wgpu",
  "wonnx",
  "wonnx-preprocessing",
@@ -3877,7 +3960,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokenizers",
- "tract-onnx",
+ "tract-onnx 0.17.0",
  "wgpu",
  "wonnx",
 ]
@@ -3899,7 +3982,7 @@ version = "0.2.4"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "js-sys",
  "log",
  "wasm-bindgen",
@@ -3930,7 +4013,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time 0.1.43",
+ "time 0.1.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
+name = "futures-intrusive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1346,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1925,12 +1939,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.13",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2281,7 +2320,7 @@ dependencies = [
  "cfg-if",
  "indoc",
  "libc",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -3728,7 +3767,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.12.1",
  "raw-window-handle",
  "smallvec",
  "wasm-bindgen",
@@ -3754,7 +3793,7 @@ dependencies = [
  "fxhash",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -3791,7 +3830,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot",
+ "parking_lot 0.12.1",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -3913,11 +3952,13 @@ dependencies = [
  "approx",
  "bytemuck",
  "env_logger",
+ "futures-intrusive",
  "image",
  "lazy_static",
  "log",
  "ndarray",
  "num",
+ "parking_lot 0.11.2",
  "pollster",
  "protobuf",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20ae67ce26261f218e2b3f2f0d01887a9818283ca6fb260fa7c67e253d61c92"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,9 +93,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ash"
-version = "0.34.0+1.2.203"
+version = "0.37.0+1.3.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
+checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
 dependencies = [
  "libloading",
 ]
@@ -532,9 +541,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "d3d12"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
+checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
 dependencies = [
  "bitflags",
  "libloading",
@@ -1326,9 +1335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1387,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1402,6 +1408,7 @@ checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1603,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
  "bitflags",
  "block",
@@ -1656,9 +1663,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "naga"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705"
+checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -1669,7 +1676,9 @@ dependencies = [
  "num-traits",
  "rustc-hash",
  "spirv",
+ "termcolor",
  "thiserror",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1940,37 +1949,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.13",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2321,7 +2305,7 @@ dependencies = [
  "cfg-if",
  "indoc",
  "libc",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -3438,6 +3422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,9 +3519,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3541,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3566,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3578,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3588,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3601,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -3631,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3647,15 +3637,15 @@ checksum = "9c97e489d8f836838d497091de568cf16b117486d529ec5579233521065bd5e4"
 
 [[package]]
 name = "wgpu"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
+checksum = "277e967bf8b7820a76852645a6bce8bbd31c32fda2042e82d8e3ea75fda8892d"
 dependencies = [
  "arrayvec 0.7.2",
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.11.2",
+ "parking_lot",
  "raw-window-handle",
  "smallvec",
  "wasm-bindgen",
@@ -3668,11 +3658,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
+checksum = "266ca6be6004fd1b2a768023b1cb0afbf7af0cbffaba19af25c5792d44e74784"
 dependencies = [
  "arrayvec 0.7.2",
+ "bit-vec",
  "bitflags",
  "cfg_aliases",
  "codespan-reporting",
@@ -3680,21 +3671,23 @@ dependencies = [
  "fxhash",
  "log",
  "naga",
- "parking_lot 0.11.2",
+ "parking_lot",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "thiserror",
+ "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.5"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2"
+checksum = "bef50e48812c7eb958fa52d28a912f8b77c96453ebab21c72b01cdda61d3e65d"
 dependencies = [
+ "android_system_properties",
  "arrayvec 0.7.2",
  "ash",
  "bit-set",
@@ -3715,7 +3708,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot 0.11.2",
+ "parking_lot",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -3729,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
+checksum = "f48d691b733b9d50ea8cb18f377fd1ed927c90c55ad1ec5b90f68885471977f7"
 dependencies = [
  "bitflags",
 ]

--- a/wonnx-cli/Cargo.toml
+++ b/wonnx-cli/Cargo.toml
@@ -24,7 +24,7 @@ protobuf = { version = "2.27.1", features = ["with-bytes"] }
 structopt = { version = "0.3.26", features = [ "paw" ] }
 thiserror = "1.0.31"
 tract-onnx = { version = "0.16.7", optional = true }
-wgpu = "0.12.0"
+wgpu = "0.13.1"
 wonnx = { path = "../wonnx" }
 wonnx-preprocessing = { path = "../wonnx-preprocessing" }
 human_bytes = "0.3.1"

--- a/wonnx-preprocessing/Cargo.toml
+++ b/wonnx-preprocessing/Cargo.toml
@@ -10,7 +10,7 @@ ndarray = "0.15.4"
 protobuf = { version = "2.27.1", features = ["with-bytes"] }
 thiserror = "1.0.31"
 tokenizers = "0.11.3"
-tract-onnx = { version = "0.16.7", optional = true }
+tract-onnx = { version = "^0.17.0", optional = true }
 wgpu = "0.13.1"
 wonnx = { path = "../wonnx" }
 serde_json = "^1.0"

--- a/wonnx-preprocessing/Cargo.toml
+++ b/wonnx-preprocessing/Cargo.toml
@@ -11,7 +11,7 @@ protobuf = { version = "2.27.1", features = ["with-bytes"] }
 thiserror = "1.0.31"
 tokenizers = "0.11.3"
 tract-onnx = { version = "0.16.7", optional = true }
-wgpu = "0.12.0"
+wgpu = "0.13.1"
 wonnx = { path = "../wonnx" }
 serde_json = "^1.0"
 

--- a/wonnx-wasm/Cargo.toml
+++ b/wonnx-wasm/Cargo.toml
@@ -27,7 +27,6 @@ lto = true
 [dependencies]
 wonnx = { path = "../wonnx" }
 log = "0.4.17"
-#wgpu = { version = "0.12.0" }
 console_log = "0.2.0"
 console_error_panic_hook = "0.1.7"
 wasm-bindgen-console-logger = "0.1.1"
@@ -36,7 +35,7 @@ wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] } # remember
 wasm-bindgen-futures = "0.4.30"
 wasm-bindgen-test = "0.3.30"
 js-sys = "0.3.57"
-web-sys = { version = "0.3.57", features = [
+web-sys = { version = "0.3.58", features = [
     "Document",
     "Navigator",
     "Node",
@@ -59,12 +58,10 @@ web-sys = { version = "0.3.57", features = [
     "GpuBufferBindingLayout",
     "GpuBufferBindingType",
     "GpuBufferDescriptor",
-    "GpuBufferUsage",
     "GpuCanvasContext",
     "GpuCanvasConfiguration",
     "GpuColorDict",
     "GpuColorTargetState",
-    "GpuColorWrite",
     "GpuCommandBuffer",
     "GpuCommandBufferDescriptor",
     "GpuCommandEncoder",
@@ -94,7 +91,6 @@ web-sys = { version = "0.3.57", features = [
     "GpuImageDataLayout",
     "GpuIndexFormat",
     "GpuLoadOp",
-    "GpuMapMode",
     "GpuMultisampleState",
     "GpuObjectDescriptorBase",
     "GpuOrigin2dDict",
@@ -103,7 +99,6 @@ web-sys = { version = "0.3.57", features = [
     "GpuPipelineDescriptorBase",
     "GpuPipelineLayout",
     "GpuPipelineLayoutDescriptor",
-    "GpuPipelineStatisticName",
     "GpuPowerPreference",
     "GpuPrimitiveState",
     "GpuPrimitiveTopology",
@@ -129,7 +124,6 @@ web-sys = { version = "0.3.57", features = [
     "GpuSamplerDescriptor",
     "GpuShaderModule",
     "GpuShaderModuleDescriptor",
-    "GpuShaderStage",
     "GpuStencilFaceState",
     "GpuStencilOperation",
     "GpuStorageTextureAccess",
@@ -144,7 +138,6 @@ web-sys = { version = "0.3.57", features = [
     "GpuTextureDimension",
     "GpuTextureFormat",
     "GpuTextureSampleType",
-    "GpuTextureUsage",
     "GpuTextureView",
     "GpuTextureViewDescriptor",
     "GpuTextureViewDimension",

--- a/wonnx-wasm/src/lib.rs
+++ b/wonnx-wasm/src/lib.rs
@@ -14,7 +14,7 @@ use wonnx::utils::{InputTensor, OutputTensor};
 pub fn main() {
     console_error_panic_hook::set_once();
     log::set_logger(&DEFAULT_LOGGER).unwrap();
-    log::set_max_level(log::LevelFilter::Info);
+    log::set_max_level(log::LevelFilter::Warn);
 }
 
 #[wasm_bindgen]

--- a/wonnx/Cargo.toml
+++ b/wonnx/Cargo.toml
@@ -30,6 +30,12 @@ serde_derive = "1.0.137"
 serde = { version = "1.0.137", features = ["derive"] }
 num = "0.4.0"
 
+# We need these on WASM because the way we are reading buffers there is slightly more involved
+# See GpuTensor::read_to_vec
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+futures-intrusive = "0.4.0"
+parking_lot = { version = "0.11.1", features = ["wasm-bindgen"]}
+
 [dev-dependencies]
 image = "0.24.2"
 ndarray = "0.15.4"

--- a/wonnx/Cargo.toml
+++ b/wonnx/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [dependencies]
-wgpu = "0.12.0"
+wgpu = "0.13.1"
 bytemuck = "1.9.1"
 protobuf = { version = "2.27.1", features = ["with-bytes"] }
 log = "0.4.17"

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -672,9 +672,9 @@ impl GpuTensor {
 
             wgpu::util::DownloadBuffer::read_buffer(device, queue, &buffer_slice, move |b| {
                 // Called on download completed
-                tx.send(match b {
-                    Ok(b) => Ok(Self::read_bytes_to_vec(&b, shape)),
-                    Err(abe) => Err(GpuError::BufferAsyncError(abe)),
+                tx.send(match buffer {
+                    Ok(bytes) => Ok(Self::read_bytes_to_vec(&bytes, shape)),
+                    Err(error) => Err(GpuError::BufferAsyncError(error)),
                 })
                 .unwrap();
             });

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -5,9 +5,10 @@ use std::{
     sync::Arc,
 };
 
+use bytemuck::NoUninit;
 use num::FromPrimitive;
 use thiserror::Error;
-use wgpu::{Buffer, BufferUsages, CommandEncoder};
+use wgpu::{Buffer, BufferAsyncError, BufferUsages, CommandEncoder};
 
 use crate::{
     compiler::{compile, CompileError, CompiledNode},
@@ -77,6 +78,9 @@ pub enum GpuError {
 
     #[error("value out of bounds")]
     OutOfBoundsError,
+
+    #[error("async buffer error: {0}")]
+    BufferAsyncError(#[from] BufferAsyncError),
 }
 
 enum InferenceOutput {
@@ -657,45 +661,64 @@ impl GpuTensor {
         queue: &wgpu::Queue,
     ) -> Result<OutputTensor, GpuError> {
         let buffer_slice = self.buffer.slice(..);
+        let shape = self.shape.clone();
 
         // On wgpu we can MAP_READ a buffer that is also used as STORAGE, but WebGPU (on at least Chrome)
         // disallows this. Therefore we need to do an additional copy into a MAP_READ buffer when reading back a
         // STORAGE buffer when on WebGPU.
         #[cfg(target_arch = "wasm32")]
-        let output_data = wgpu::util::DownloadBuffer::read_buffer(device, queue, &buffer_slice)
-            .await
-            .unwrap();
+        {
+            let (tx, rx) = futures_intrusive::channel::shared::oneshot_channel();
+
+            wgpu::util::DownloadBuffer::read_buffer(device, queue, &buffer_slice, move |b| {
+                // Called on download completed
+                tx.send(match b {
+                    Ok(b) => Ok(Self::read_bytes_to_vec(&b, shape)),
+                    Err(abe) => Err(GpuError::BufferAsyncError(abe)),
+                })
+                .unwrap();
+            });
+            device.poll(wgpu::Maintain::Wait);
+            // The callback will have been called by now due to poll(Wait)
+            rx.receive().await.unwrap()
+        }
 
         #[cfg(not(target_arch = "wasm32"))]
-        let output_data = {
-            let _ = queue; // Need this because otherwise compiler complains we are not using the queue parameter
-            buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
-            device.poll(wgpu::Maintain::Wait);
-            buffer_slice.get_mapped_range()
-        };
+        {
+            let output_data = {
+                let _ = queue; // Need this because otherwise compiler complains we are not using the queue parameter
+                buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
+                device.poll(wgpu::Maintain::Wait);
+                buffer_slice.get_mapped_range()
+            };
 
+            let result = Self::read_bytes_to_vec(&output_data[..], shape);
+            drop(output_data);
+            self.buffer.unmap();
+            Ok(result)
+        }
+    }
+
+    fn read_bytes_to_vec<A>(output_data: &[A], shape: Shape) -> OutputTensor
+    where
+        A: NoUninit,
+    {
         // The actual buffer may be bigger than what we should return, because buffers have a minimum size in wgpu
         // Fetch the size we should expect so we can chop the buffer to the correct size
-        let output_buffer_size = self.shape.element_count() as usize;
-        let result = match self.shape.data_type {
+        let output_buffer_size = shape.element_count() as usize;
+        match shape.data_type {
             ScalarType::F32 => {
-                OutputTensor::F32(bytemuck::cast_slice(&output_data)[..output_buffer_size].to_vec())
+                OutputTensor::F32(bytemuck::cast_slice(output_data)[..output_buffer_size].to_vec())
             }
             ScalarType::I32 => {
-                OutputTensor::I32(bytemuck::cast_slice(&output_data)[..output_buffer_size].to_vec())
+                OutputTensor::I32(bytemuck::cast_slice(output_data)[..output_buffer_size].to_vec())
             }
             ScalarType::I64 => {
                 log::warn!("reading int64 output as int32 because internally int64 scalars are not supported");
                 let result_ints: Vec<i32> =
-                    bytemuck::cast_slice(&output_data)[..output_buffer_size].to_vec();
+                    bytemuck::cast_slice(output_data)[..output_buffer_size].to_vec();
                 OutputTensor::I64(result_ints.iter().map(|i| *i as i64).collect())
             }
-        };
-        drop(output_data);
-
-        // On WASM we are not mapping the buffer, so we don't need to unmap
-        #[cfg(not(target_arch = "wasm32"))]
-        self.buffer.unmap();
-        Ok(result)
+        }
     }
 }

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -544,7 +544,7 @@ impl<'model> OperatorDefinition<'model> {
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label,
             layout: None,
-            module: &device.create_shader_module(&wgpu::ShaderModuleDescriptor {
+            module: &device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label,
                 source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(&shader)),
             }),
@@ -642,7 +642,7 @@ impl GpuStep {
                     compute_pass.set_bind_group(index as u32, bind_group, &[]);
                 }
                 let (x, y, z) = *threads;
-                compute_pass.dispatch(x, y, z);
+                compute_pass.dispatch_workgroups(x, y, z);
                 Ok(())
             }
         }
@@ -669,9 +669,8 @@ impl GpuTensor {
         #[cfg(not(target_arch = "wasm32"))]
         let output_data = {
             let _ = queue; // Need this because otherwise compiler complains we are not using the queue parameter
-            let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
+            buffer_slice.map_async(wgpu::MapMode::Read, |_| {});
             device.poll(wgpu::Maintain::Wait);
-            buffer_future.await.expect("failed to run compute on gpu!");
             buffer_slice.get_mapped_range()
         };
 

--- a/wonnx/src/utils.rs
+++ b/wonnx/src/utils.rs
@@ -254,6 +254,13 @@ impl ScalarType {
             ScalarType::I64 => "i64",
         }
     }
+
+    pub fn is_float(&self) -> bool {
+        match self {
+            ScalarType::F32 => true,
+            ScalarType::I32 | ScalarType::I64 => false,
+        }
+    }
 }
 
 impl Display for ScalarType {

--- a/wonnx/templates/endomorphism/activation.wgsl
+++ b/wonnx/templates/endomorphism/activation.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: ArrayVector;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{% set activation_input = "input_0.data[gidx]" %}

--- a/wonnx/templates/endomorphism/arithmetic.wgsl
+++ b/wonnx/templates/endomorphism/arithmetic.wgsl
@@ -1,43 +1,43 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
 {% if i_lens | length == 2 %}
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: ArrayVector;
 
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, write> output_0: ArrayVector;
 
 {% else %}
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: ArrayVector;
 
 {% endif %}
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }}, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{% if i_lens | length == 2 %}
 		{% if op_type == "Pow" %}
 			output_0.data[gidx] = pow(input_0.data[gidx], input_1.data[gidx]);
 		{% elif op_type == "PRelu" %}
-			output_0.data[gidx] = max(input_0.data[gidx], Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)))
-	                            + min(input_0.data[gidx], Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0))) * input_1.data[gidx];
+			output_0.data[gidx] = max(input_0.data[gidx], Vec4(Scalar(), Scalar(), Scalar(), Scalar()))
+	                            + min(input_0.data[gidx], Vec4(Scalar(), Scalar(), Scalar(), Scalar())) * input_1.data[gidx];
 		{% else %}
 			output_0.data[gidx] = input_0.data[gidx] {{ op_type }} input_1.data[gidx];
 		{% endif %}
 
 	{% else %}
 		output_0.data[gidx] = input_0.data[gidx] {{ op_type }} Vec4(
-			Scalar({{ coefficient }}), 
-			Scalar({{ coefficient }}),
-			Scalar({{ coefficient }}),
-			Scalar({{ coefficient }})
+			{{ scalar_type }}({{ coefficient }}), 
+			{{ scalar_type }}({{ coefficient }}),
+			{{ scalar_type }}({{ coefficient }}),
+			{{ scalar_type }}({{ coefficient }})
 		);
 	{% endif %}
 }

--- a/wonnx/templates/endomorphism/batchnormalization.wgsl
+++ b/wonnx/templates/endomorphism/batchnormalization.wgsl
@@ -2,35 +2,35 @@
 {%- include "structs.wgsl" -%}
 
 struct Block {
-	data: [[stride({{ elem_stride }})]] array<{{ elem_type }}>;
+	data: array<{{ elem_type }}>
 };
 
 // X (input)
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Block;
 
 // Scale
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Array;
 
 // B (bias)
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, read> input_2: Array;
 
 // Input mean
-[[group(0), binding(3)]]
+@group(0) @binding(3)
 var<storage, read> input_3: Array;
 
 // Input variance
-[[group(1), binding(0)]]
+@group(1) @binding(0)
 var<storage, read> input_4: Array;
 
 // Y (Output)
-[[group(1), binding(1)]]
+@group(1) @binding(1)
 var<storage, write> output_0: Block;
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let channel = global_id.y;
 	let batch = global_id.z;
 	let index = global_id.x + batch * {{ batch_size }}u + channel * {{ channel_size }}u;

--- a/wonnx/templates/endomorphism/broadcast.wgsl
+++ b/wonnx/templates/endomorphism/broadcast.wgsl
@@ -1,16 +1,16 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Array;
 
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }}, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{# We will be called for each element in the output tensor. Determine the corresponding indices in the source tensors #}
@@ -38,8 +38,8 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	{% if op_type == "Pow" %}
 		output_0.data[gidx] = pow(lhs, rhs);
 	{% elif op_type == "PRelu" %}
-		output_0.data[gidx] = max(lhs, Scalar(0))
-							+ min(lhs, Scalar(0)) * rhs;
+		output_0.data[gidx] = max(lhs, Scalar())
+							+ min(lhs, Scalar()) * rhs;
 	{% else %}
 		output_0.data[gidx] = (lhs {{ op_type }} rhs);
 	{% endif %}

--- a/wonnx/templates/endomorphism/cast.wgsl
+++ b/wonnx/templates/endomorphism/cast.wgsl
@@ -1,16 +1,16 @@
 {%- include "structs.wgsl" -%}
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
 struct OutputArrayVector {
-	data: [[stride({{ vec4_stride }})]] array<vec4<{{ cast_to_type }}>>;
+	data: array<vec4<{{ cast_to_type }}>>
 }; 
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: OutputArrayVector;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let gidx = global_id.x;
     output_0.data[gidx] = vec4<{{ cast_to_type }}>(input_0.data[gidx]);
 }

--- a/wonnx/templates/endomorphism/gather.wgsl
+++ b/wonnx/templates/endomorphism/gather.wgsl
@@ -1,24 +1,24 @@
 {%- include "structs.wgsl" -%}
 
 struct Indices {
-	data: [[stride(4)]] array<i32>;
+	data: array<i32>
 };
 
 struct Chunk {
-	data: [[stride({{ scalar_stride * chunk_size }})]] array<{{ chunk_type }}>;
+	data: array<{{ chunk_type }}>
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Chunk; // data
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Indices; // indices
 
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, write> output_0: Chunk;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let index_index = global_id.x; // Index of the index in the indices array that we are currently processing
 	let chunk_index = global_id.y; // Chunk of elements that we are copying for this index (chunk size determined dynamically)
 	let index_stride = {{ i_chunks[0][0] / chunk_size }}u;

--- a/wonnx/templates/endomorphism/map.wgsl
+++ b/wonnx/templates/endomorphism/map.wgsl
@@ -1,22 +1,23 @@
 {%- include "structs.wgsl" -%}
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: ArrayVector;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	
 	{% if op_type == "Reciprocal" %}
-		let one = Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1));
+		let one_scalar = {{scalar_type}}(1);
+		let one = Vec4(one_scalar, one_scalar, one_scalar, one_scalar);
 		output_0.data[gidx] = one / (input_0.data[gidx]);
 	{% elif op_type == "Tanh" %}
 		{# Tanh will produce NaNs when fed with inputs that are much larger than +10.0 or smaller than -10.0. As the output
 		for these inputs converges to 1.0 and -1.0 respectively, we clamp the inputs first. #}
-		let one = Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1));
-		let boundary = one * Scalar(10);
+		let one = Vec4(one_scalar, one_scalar, one_scalar, one_scalar);
+		let boundary = one * {{ scalar_type }}(10);
 		let intermediate = max(-boundary, min(boundary, input_0.data[gidx]));
 		output_0.data[gidx] = tanh(intermediate);
 	{% else %}

--- a/wonnx/templates/endomorphism/map.wgsl
+++ b/wonnx/templates/endomorphism/map.wgsl
@@ -16,6 +16,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	{% elif op_type == "Tanh" %}
 		{# Tanh will produce NaNs when fed with inputs that are much larger than +10.0 or smaller than -10.0. As the output
 		for these inputs converges to 1.0 and -1.0 respectively, we clamp the inputs first. #}
+		let one_scalar = {{scalar_type}}(1);
 		let one = Vec4(one_scalar, one_scalar, one_scalar, one_scalar);
 		let boundary = one * {{ scalar_type }}(10);
 		let intermediate = max(-boundary, min(boundary, input_0.data[gidx]));

--- a/wonnx/templates/endomorphism/onehot.wgsl
+++ b/wonnx/templates/endomorphism/onehot.wgsl
@@ -1,27 +1,27 @@
 {%- include "structs.wgsl" -%}
 
 struct Indices {
-	data: [[stride(4)]] array<i32>;
+	data: array<i32>
 };
 
 struct Depth {
-	data: i32;
+	data: i32
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_indexes: Indices;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_depth: Depth;
 
-[[group(0), binding(2)]]
+@group(0) @binding(2)
 var<storage, read> input_values: Array;
 
-[[group(0), binding(3)]]
+@group(0) @binding(3)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let index_of_index = global_id.x;
 	let depth = u32(input_depth.data);
 	var index = input_indexes.data[index_of_index];

--- a/wonnx/templates/endomorphism/softmax.wgsl
+++ b/wonnx/templates/endomorphism/softmax.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	let chunk_start = gidx * {{ axis_chunk }}u + global_id.y;
 
@@ -24,14 +24,14 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	// First, determine max(input)
 	// WGSL doesn't have a way to write -Infinity (https://github.com/gpuweb/gpuweb/issues/1769)
 	// Therefore we use log(0) instead which returns -Infinity
-	var max_element: Scalar = log(Scalar(0));
+	var max_element: Scalar = log(Scalar());
 	for(var k: u32 = 0u; k < n_elements; k = k + 1u) {
 		let element = input_0.data[chunk_start + (k * element_stride)];
 		max_element = max(max_element, element);
 	}
 
 	// Calculate sum(exp(input - max(input)))
-	var sum: Scalar = Scalar(0);
+	var sum: Scalar = Scalar();
 	for(var k: u32 = 0u; k < n_elements; k = k + 1u) {
 		let element = input_0.data[chunk_start + (k * element_stride)];
 		sum  = sum + exp(element - max_element);

--- a/wonnx/templates/matrix/concat.wgsl
+++ b/wonnx/templates/matrix/concat.wgsl
@@ -3,17 +3,17 @@
 
 {% for input in i_lens %}
 
-[[group({{ loop.index0 / 4 | int }}), binding({{ loop.index0 % 4}})]]
+@group({{ loop.index0 / 4 | int }}) @binding({{ loop.index0 % 4}})
 var<storage, read> input_{{ loop.index0 }}: Array;
 
 {% endfor %}
 
 {% set binding_len = i_lens | length %}
-[[group({{ binding_len  / 4 | int }}), binding({{ binding_len % 4 }})]]
+@group({{ binding_len  / 4 | int }}) @binding({{ binding_len % 4 }})
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	
 	{% for input in i_lens %}

--- a/wonnx/templates/matrix/gemm.wgsl
+++ b/wonnx/templates/matrix/gemm.wgsl
@@ -3,28 +3,28 @@ type GemmVec = vec{{ kernel_size }}<{{ scalar_type }}>;
 type GemmMat = mat{{ kernel_size }}x{{ kernel_size }}<{{ scalar_type }}>;
 
 struct GemmArrayVector {
-	data: array<GemmVec>;
+	data: array<GemmVec>
 };
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_left: GemmArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_right: GemmArrayVector;
 
 {% if i_lens | length == 3 %} // Bias
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_bias: GemmArrayVector;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: GemmArrayVector;
 {% else %}
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: GemmArrayVector;
 {% endif %}
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let y = global_id.x % {{ n_chunks }}u;
 	let x = global_id.x / {{ n_chunks }}u;
 
@@ -39,7 +39,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	{# Create zero vector and matrix of the correct size for later use #}
 	let zero_vec = GemmVec(
 		{% for i in range(end = kernel_size) %}
-			Scalar(0) {%-if not loop.last -%},{%- endif -%}
+			Scalar() {%-if not loop.last -%},{%- endif -%}
 		{% endfor %}
 	);
 

--- a/wonnx/templates/matrix/gemm_1.wgsl
+++ b/wonnx/templates/matrix/gemm_1.wgsl
@@ -1,28 +1,28 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Array;
 
 {%- if i_lens | length == 3 -%} // Bias
 
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_2: Array;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: Array;
 
 {%- else -%}
 
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: Array;
 
 {%- endif -%}  
 
-[[stage(compute), workgroup_size(1, {{ workgroup_size_y }})]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(1, {{ workgroup_size_y }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{# Calculate stacking offsets #}
@@ -30,8 +30,8 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	let right_offset = global_id.y * {{ stack_right_stride }}u;
 	let output_offset = global_id.y * {{ stack_output_stride }}u;
 
-	var tmpsum = Scalar(0);
-	var product = Scalar(0);
+	var tmpsum = Scalar();
+	var product = Scalar();
 
 	for(var k: u32 = 0u; k < {{ left_shape[1] / 4 | int }}u; k = k + 1u) {
 		let index_left = left_offset + k; 

--- a/wonnx/templates/matrix/pad.wgsl
+++ b/wonnx/templates/matrix/pad.wgsl
@@ -1,14 +1,14 @@
 
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	if (gidx < {{ o_lens[0] }}u) {
@@ -38,7 +38,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		{% endfor %}
 
 		if (pad) {
-			output_0.data[gidx] = Scalar({{ constant_value }});
+			output_0.data[gidx] = {{ scalar_type }}({{ constant_value }});
 		} else {
 			let index = 
 				{%- for chunk in i_chunks | first -%}

--- a/wonnx/templates/matrix/resize.wgsl
+++ b/wonnx/templates/matrix/resize.wgsl
@@ -1,14 +1,14 @@
 
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	if (gidx < {{ o_lens[0] }}u) {
@@ -29,7 +29,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 					+ 
 				{%- endif -%}
 				u32(floor(
-					(Scalar(d_{{ loop.index0 }}) + Scalar(0.5)) / {{ scale }} - Scalar(0.5) 
+					({{ scalar_type }}(d_{{ loop.index0 }}) + {{ scalar_type }}(0.5)) / {{ scale }} - {{ scalar_type }}(0.5) 
 				)) * {{ chunks  }}u 
 			{%- endfor -%}
 		;

--- a/wonnx/templates/matrix/split.wgsl
+++ b/wonnx/templates/matrix/split.wgsl
@@ -1,16 +1,16 @@
 
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
 {% for output in o_lens %}
-	[[group({{ loop.index / 4 | int }}), binding({{ loop.index % 4}})]]
+	@group({{ loop.index / 4 | int }}) @binding({{ loop.index % 4}})
 	var<storage, write> output_{{ loop.index0 }}: Array;
 {% endfor %}
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	if (gidx < {{ i_lens[0] }}u) {

--- a/wonnx/templates/matrix/transpose.wgsl
+++ b/wonnx/templates/matrix/transpose.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	if (gidx < {{ o_lens[0] }}u) {

--- a/wonnx/templates/pool/aggregate.wgsl
+++ b/wonnx/templates/pool/aggregate.wgsl
@@ -1,13 +1,13 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{% if (i_shape[0][1] % 4) == 0 %}
@@ -22,9 +22,9 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		let x = rest % {{ o_chunks[0][2] }}u;
 		
 		{% if op_type == "AveragePool" -%}
-		var result = Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0));
+		var result = Vec4(Scalar(), Scalar(), Scalar(), Scalar());
 		{% else %}
-		var result = Vec4(Scalar(-3.40282347E+38), Scalar(-3.40282347E+38), Scalar(-3.40282347E+38), Scalar(-3.40282347E+38));
+		var result = Vec4({{ scalar_type }}(-3.40282347E+38), {{ scalar_type }}(-3.40282347E+38), {{ scalar_type }}(-3.40282347E+38), {{ scalar_type }}(-3.40282347E+38));
 		{% endif %}
 		var value = result;
 
@@ -32,7 +32,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		var tmp_y = 0u;
 		var tmp_x = 0u;
 		var tmp_index = 0u;
-		var counter = Scalar(0);
+		var counter = Scalar();
 
 		for(var i: u32 = 0u; i < {{ kernel_shape[0] }}u; i = i + 1u) {
 			tmp_y = y * {{ stride[0] }}u + i * {{ dilation[0] }}u - {{ pad[0] }}u; 
@@ -54,7 +54,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 								result = max(result, value);
 							{%- elif op_type == "AveragePool" -%}
 								result = result + value;
-								counter = counter + Scalar(1);
+								counter = counter + {{ scalar_type }}(1);
 							{%- endif -%}
 						}
 				}
@@ -90,9 +90,9 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		let x = rest % {{ o_chunks[0][2] }}u;
 		
 		{% if op_type == "AveragePool" -%}
-		var result = Scalar(0);
+		var result = Scalar();
 		{% else %}
-		var result = Scalar(-3.40282347E+38);
+		var result = {{ scalar_type }}(-3.40282347E+38);
 		{% endif %}
 		var value = result;
 		
@@ -100,7 +100,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		var tmp_y = 0u;
 		var tmp_x = 0u;
 		var tmp_index = 0u;
-		var counter = Scalar(0);
+		var counter = Scalar();
 
 		for(var i: u32 = 0u; i < {{ kernel_shape[0] }}u; i = i + 1u) {
 			tmp_y = y * {{ stride[0] }}u + i * {{ dilation[0] }}u - {{ pad[0] }}u; 
@@ -117,7 +117,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 								result = max(result, value);
 							{%- elif op_type == "AveragePool" -%}
 								result = result + value;
-								counter = counter + Scalar(1);
+								counter = counter + {{ scalar_type }}(1);
 							{%- endif -%}
 						}
 				}

--- a/wonnx/templates/pool/aggregate.wgsl
+++ b/wonnx/templates/pool/aggregate.wgsl
@@ -1,5 +1,12 @@
 {%- include "structs.wgsl" -%}
 
+{# 
+// The smallest floating point number that can be represented in IEEE-754. This should be -3.40282347E+38. However, Google 
+// Chrome's WGSL compiler (as of July 2022) complains that number cannot be represented in f32. Hence we are using +37f,
+// which should be sufficiently low.
+#}
+{% set_global min_float = scalar_type ~ "(-3.40282347E+37f)" %}
+
 @group(0) @binding(0)
 var<storage, read> input_0: Array;
 
@@ -24,7 +31,12 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 		{% if op_type == "AveragePool" -%}
 		var result = Vec4(Scalar(), Scalar(), Scalar(), Scalar());
 		{% else %}
-		var result = Vec4({{ scalar_type }}(-3.40282347E+38), {{ scalar_type }}(-3.40282347E+38), {{ scalar_type }}(-3.40282347E+38), {{ scalar_type }}(-3.40282347E+38));
+		var result = Vec4(
+			{{ min_float }},
+			{{ min_float }},
+			{{ min_float }},
+			{{ min_float }}
+		);
 		{% endif %}
 		var value = result;
 
@@ -92,7 +104,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 		{% if op_type == "AveragePool" -%}
 		var result = Scalar();
 		{% else %}
-		var result = {{ scalar_type }}(-3.40282347E+38);
+		
+		var result = {{ scalar_type }}({{ min_float }});
 		{% endif %}
 		var value = result;
 		

--- a/wonnx/templates/pool/conv.wgsl
+++ b/wonnx/templates/pool/conv.wgsl
@@ -1,26 +1,26 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: Array;
 
 {%- if i_lens | length == 3 -%} // Bias
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_2: Array;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: Array;
 
 {%- else -%}
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: Array;
 
 {%- endif %}
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	if (gidx < {{ o_lens[0] }}u) {
 		let batch = gidx / {{ o_chunks[0][0] }}u; 
@@ -32,7 +32,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		let y = rest / {{ o_chunks[0][2] }}u;
 		let x = rest % {{ o_chunks[0][2] }}u;
 		
-		var result: Scalar = Scalar(0);
+		var result: Scalar = Scalar();
 
 		let root_index = batch * {{ i_chunks[0][0] }}u;
 		let root_kernel_index = m * {{ kernel_channel_len }}u;

--- a/wonnx/templates/pool/conv_kernel_1.wgsl
+++ b/wonnx/templates/pool/conv_kernel_1.wgsl
@@ -1,27 +1,27 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: ArrayMatrix;
 
 {%- if i_lens | length == 3 -%} // Bias
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_2: ArrayVector;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: Array;
 
 {%- else -%}
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: Array;
 
 {%- endif %}
 
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	if (gidx < {{ o_lens[0]/4 }}u) {
 		let batch = gidx / {{ o_chunks[0][0] / 4 }}u; 
@@ -30,7 +30,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		let m = rest / {{ o_chunks[0][1] }}u;
 		let xy = rest % {{ o_chunks[0][1] }}u;
 			
-		var result = Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0));
+		var result = Vec4(Scalar(), Scalar(), Scalar(), Scalar());
 		
 		let root_index = batch * {{ i_chunks[0][0] }}u + xy;
 		let root_kernel_index = m * {{ channel / 16 * 4 }}u;

--- a/wonnx/templates/pool/conv_kernel_3.wgsl
+++ b/wonnx/templates/pool/conv_kernel_3.wgsl
@@ -1,26 +1,26 @@
 {%- include "structs.wgsl" -%}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, read> input_1: ArrayMatrix3;
 
 {%- if i_lens | length == 3 -%} // Bias
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, read> input_2: ArrayVector;
 
-	[[group(0), binding(3)]]
+	@group(0) @binding(3)
 	var<storage, write> output_0: Array;
 
 {%- else -%}
-	[[group(0), binding(2)]]
+	@group(0) @binding(2)
 	var<storage, write> output_0: Array;
 
 {%- endif %}
 
-[[stage(compute), workgroup_size(256, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 	if (gidx < {{ o_lens[0]/4 }}u) {
 		let batch = gidx / {{ o_chunks[0][0] / 4 }}u; 
@@ -32,7 +32,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		let y = rest / {{ o_chunks[0][2] }}u;
 		let x = rest % {{ o_chunks[0][2] }}u;
 		
-		var result = Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0));
+		var result = Vec4(Scalar(), Scalar(), Scalar(), Scalar());
 		
 		let root_index = batch * {{ i_chunks[0][0] }}u;
 		let root_kernel_index = m * {{ channel * 4 }}u;
@@ -47,7 +47,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 			var kernel_matrix_3 = input_1.data[base_kernel_index + {{ 3 * channel }}u];
 
 			for(var i: u32 = 0u; i < {{ kernel_shape[0] }}u; i = i + 1u) {
-				var tmp_vec = Vec3(Scalar(0), Scalar(0), Scalar(0));
+				var tmp_vec = Vec3(Scalar(), Scalar(), Scalar());
 				let tmp_y = y * {{ stride[0] }}u + i * {{ dilation[0] }}u - {{ pad[0] }}u; 
 				
 				if ((tmp_y < {{ original_height }}u) && (tmp_y >= 0u)) {

--- a/wonnx/templates/pool/reduce.wgsl
+++ b/wonnx/templates/pool/reduce.wgsl
@@ -1,13 +1,13 @@
 {% include "structs.wgsl" %}
 
-[[group(0), binding(0)]]
+@group(0) @binding(0)
 var<storage, read> input_0: Array;
 
-[[group(0), binding(1)]]
+@group(0) @binding(1)
 var<storage, write> output_0: Array;
 
-[[stage(compute), workgroup_size({{ workgroup_size_x }}, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+@compute @workgroup_size({{ workgroup_size_x }}, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{# We will be invoked once for each scalar in the output (output_0.data[gidx]) which represents one reduce operation.
@@ -40,7 +40,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		Now for each reduced axis, iterate all values and reduce. Note, starting value may not always be zero. For 
 		ReduceMin/Max we should initialize as NaN and keep a flag to check if we have seen at least one element -#}
 
-		var accumulator = {% if op_type == "ReduceProd" %} Scalar(1) {% else %} Scalar(0) {% endif %}; 
+		var accumulator = {% if op_type == "ReduceProd" %} {{ scalar_type }}(1) {% else %} Scalar() {% endif %}; 
 		var count = 0u;
 
 		{% for reducing_axis in axes %}
@@ -89,7 +89,7 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 
 		{#- Post-processing -#}
 		{% if op_type == "ReduceMean" %}
-			accumulator = accumulator / Scalar(count);
+			accumulator = accumulator / {{ scalar_type }}(count);
 		{% elif op_type == "ReduceL2" %}
 			accumulator = sqrt(accumulator);
 		{% elif op_type == "ReduceLogSum" or op_type == "ReduceLogSumExp" %}

--- a/wonnx/templates/snippets/activation_scalar.wgsl
+++ b/wonnx/templates/snippets/activation_scalar.wgsl
@@ -1,15 +1,15 @@
 {%- if activation_type == "Relu" -%}
-	{{ activation_output }} = max({{ activation_input }}, Scalar(0));
+	{{ activation_output }} = max({{ activation_input }}, Scalar());
 
 {%- elif activation_type == "Sigmoid" -%}
-	{{ activation_output }} = Scalar(1) / (Scalar(1) + exp(-{{ activation_input }}));
+	{{ activation_output }} = {{ scalar_type }}(1) / ({{ scalar_type }}(1) + exp(-{{ activation_input }}));
 
 {%- elif activation_type == "Softsign" -%}
 	let input = {{ activation_input }}; 
-	{{ activation_output }} = input / (Scalar(1) + abs(input));
+	{{ activation_output }} = input / ({{ scalar_type }}(1) + abs(input));
 
 {%- elif activation_type == "Softplus" -%}
-	{{ activation_output }} = log(Scalar(1) + exp({{ activation_input }}));
+	{{ activation_output }} = log({{ scalar_type }}(1) + exp({{ activation_input }}));
 
 {%- elif activation_type == "Clip" -%}
 	let min_clip = input_1.data[0u];
@@ -24,21 +24,21 @@
 {%- elif activation_type == "Celu" -%}
 	let input_vec = {{ activation_input }};
 
-	{{ activation_output }} = max(Scalar(0), 
+	{{ activation_output }} = max(Scalar(), 
 			input_vec
 		) + min(
-			Scalar(0), 
-			{{ alpha }} * (exp(input_vec / {{ alpha }}) - Scalar(1))
+			Scalar(), 
+			{{ alpha }} * (exp(input_vec / {{ alpha }}) - {{ scalar_type }}(1))
 		);
 
 {%- elif activation_type == "Elu" -%}
 		let input_vec = {{ activation_input }}; 
 		{{ activation_output }} = max(
-			Scalar(0), 
+			Scalar(), 
 			input_vec
 		) + min(
-			Scalar(0), 
-			{{ alpha }} * (exp(input_vec) - Scalar(1))
+			Scalar(), 
+			{{ alpha }} * (exp(input_vec) - {{ scalar_type }}(1))
 		);
 
 {%- elif activation_output != activation_input -%}

--- a/wonnx/templates/snippets/activation_vec.wgsl
+++ b/wonnx/templates/snippets/activation_vec.wgsl
@@ -1,15 +1,15 @@
 {%- if activation_type == "Relu"-%}
-	{{ activation_output }} = max({{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)));
+	{{ activation_output }} = max({{ activation_input }}, Vec4(Scalar(), Scalar(), Scalar(), Scalar()));
 
 {%- elif activation_type == "Sigmoid" -%}
-	{{ activation_output }} = Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)) / (Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)) + exp(-{{ activation_input }}));
+	{{ activation_output }} = Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)) / (Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)) + exp(-{{ activation_input }}));
 
 {%- elif activation_type == "Softsign" -%}
 	let input = {{ activation_input }}; 
-	{{ activation_output }} = input / (Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)) + abs(input));
+	{{ activation_output }} = input / (Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)) + abs(input));
 
 {%- elif activation_type == "Softplus" -%}
-	{{ activation_output }} = log(Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)) + exp({{ activation_input }}));
+	{{ activation_output }} = log(Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)) + exp({{ activation_input }}));
 
 {%- elif activation_type == "Clip" -%}
 	let min_clip = input_1.data[0u];
@@ -23,30 +23,30 @@
 {%- elif activation_type == "Celu" -%}
 	let input_vec = {{ activation_input }}; 
 	{{ activation_output }} = max(
-			Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)), 
+			Vec4(Scalar(), Scalar(), Scalar(), Scalar()), 
 			input_vec
 		) + min(
-			Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)), 
-			{{ alpha }} * (exp(input_vec / {{ alpha }}) - Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)))
+			Vec4(Scalar(), Scalar(), Scalar(), Scalar()), 
+			{{ alpha }} * (exp(input_vec / {{ alpha }}) - Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)))
 		);
 
 {%- elif activation_type == "Elu" -%}
 		let input_vec = {{ activation_input }}; 
 		{{ activation_output }} = max(
-			Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)), 
+			Vec4(Scalar(), Scalar(), Scalar(), Scalar()), 
 			input_vec
 		) + min(
-			Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)), 
-			{{ alpha }} * (exp(input_vec) - Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)))
+			Vec4(Scalar(), Scalar(), Scalar(), Scalar()), 
+			{{ alpha }} * (exp(input_vec) - Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)))
 		);
 
 {%- elif activation_type == "Mish" -%}
 	let input_vec = {{ activation_input }}; 
-	{{ activation_output }} = input_vec * tanh(log(Vec4(Scalar(1), Scalar(1), Scalar(1), Scalar(1)) + exp(input_vec)));
+	{{ activation_output }} = input_vec * tanh(log(Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)) + exp(input_vec)));
 
 {%- elif activation_type == "LeakyRelu" -%}
-	{{ activation_output }} = max({{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)))
-	                         + min(Scalar({{ alpha }}) * {{ activation_input }}, Vec4(Scalar(0), Scalar(0), Scalar(0), Scalar(0)));
+	{{ activation_output }} = max({{ activation_input }}, Vec4(Scalar(), Scalar(), Scalar(), Scalar()))
+	                         + min({{ scalar_type }}({{ alpha }}) * {{ activation_input }}, Vec4(Scalar(), Scalar(), Scalar(), Scalar()));
 
 {%- elif activation_output != activation_input -%}
 	{{ activation_output }} = {{ activation_input }};

--- a/wonnx/templates/structs.wgsl
+++ b/wonnx/templates/structs.wgsl
@@ -2,7 +2,6 @@
 // Operations usually work with a single scalar data type (typically f32). This data type is set by the compiler as the
 // 'scalar_type' variable. Here we define several other useful data types that shader code can use to make it more portable.
 #}
-
 type Scalar = {{ scalar_type }};
 type Vec3 = vec3<{{ scalar_type }}>;
 type Vec4 = vec4<{{ scalar_type }}>;

--- a/wonnx/templates/structs.wgsl
+++ b/wonnx/templates/structs.wgsl
@@ -6,23 +6,29 @@
 type Scalar = {{ scalar_type }};
 type Vec3 = vec3<{{ scalar_type }}>;
 type Vec4 = vec4<{{ scalar_type }}>;
-type Mat3x3 = mat3x3<{{ scalar_type }}>;
-type Mat4x4 = mat4x4<{{ scalar_type }}>;
-type Mat4x3 = mat4x3<{{ scalar_type }}>;
 
 struct Array {
-	data: [[stride({{ scalar_stride }})]] array<Scalar>;
+	data: array<Scalar>
 };
 
 struct ArrayVector {
-	data: [[stride({{ vec4_stride }})]] array<Vec4>;
+	data: array<Vec4>
 };
 
-struct ArrayMatrix {
-	data: [[stride({{ mat4x4_stride }})]] array<Mat4x4>;
-};
+{# 
+// WGSL only supports matrixes for floating point types at this point 
+#}
+{% if scalar_type_is_float %}
+	type Mat3x3 = mat3x3<{{ scalar_type }}>;
+	type Mat4x4 = mat4x4<{{ scalar_type }}>;
+	type Mat4x3 = mat4x3<{{ scalar_type }}>;
 
-struct ArrayMatrix3 {
-	data: [[stride({{ mat3x3_stride }})]] array<Mat3x3>;
-};
+	struct ArrayMatrix {
+		data: array<Mat4x4>
+	};
+
+	struct ArrayMatrix3 {
+		data: array<Mat3x3>
+	};
+{% endif %}
 


### PR DESCRIPTION
This PR upgrades wgsl from v0.12.0 to v.0.13.1. This is a long awaited update that (among other things) updates the WGSL syntax to follow the latest standard (which e.g. Google Chrome (Tint) currently uses as well).

Tests pass on my machine and all examples work. Will do some more testing, there may be some edge cases here and there (in particular for ops where scalar_type is an integer - we can't use matrixes anymore for these because WGSL now only supports float-based matrixes).