### PR TITLE
fix: use read_write access mode for variables in 'storage' address

### DIFF
--- a/wonnx/templates/endomorphism/activation.wgsl
+++ b/wonnx/templates/endomorphism/activation.wgsl
@@ -4,7 +4,7 @@
 var<storage, read> input_0: ArrayVector;
 
 @group(0) @binding(1)
-var<storage, write> output_0: ArrayVector;
+var<storage, read_write> output_0: ArrayVector;
 
 @compute @workgroup_size({{ workgroup_size_x }})
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/endomorphism/arithmetic.wgsl
+++ b/wonnx/templates/endomorphism/arithmetic.wgsl
@@ -9,12 +9,12 @@ var<storage, read> input_0: ArrayVector;
 var<storage, read> input_1: ArrayVector;
 
 @group(0) @binding(2)
-var<storage, write> output_0: ArrayVector;
+var<storage, read_write> output_0: ArrayVector;
 
 {% else %}
 
 @group(0) @binding(1)
-var<storage, write> output_0: ArrayVector;
+var<storage, read_write> output_0: ArrayVector;
 
 {% endif %}
 

--- a/wonnx/templates/endomorphism/batchnormalization.wgsl
+++ b/wonnx/templates/endomorphism/batchnormalization.wgsl
@@ -27,7 +27,7 @@ var<storage, read> input_4: Array;
 
 // Y (Output)
 @group(1) @binding(1)
-var<storage, write> output_0: Block;
+var<storage, read_write> output_0: Block;
 
 @compute @workgroup_size(1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/endomorphism/broadcast.wgsl
+++ b/wonnx/templates/endomorphism/broadcast.wgsl
@@ -7,7 +7,7 @@ var<storage, read> input_0: Array;
 var<storage, read> input_1: Array;
 
 @group(0) @binding(2)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size({{ workgroup_size_x }}, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/endomorphism/cast.wgsl
+++ b/wonnx/templates/endomorphism/cast.wgsl
@@ -7,7 +7,7 @@ struct OutputArrayVector {
 }; 
 
 @group(0) @binding(1)
-var<storage, write> output_0: OutputArrayVector;
+var<storage, read_write> output_0: OutputArrayVector;
 
 @compute @workgroup_size({{ workgroup_size_x }})
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/endomorphism/gather.wgsl
+++ b/wonnx/templates/endomorphism/gather.wgsl
@@ -15,7 +15,7 @@ var<storage, read> input_0: Chunk; // data
 var<storage, read> input_1: Indices; // indices
 
 @group(0) @binding(2)
-var<storage, write> output_0: Chunk;
+var<storage, read_write> output_0: Chunk;
 
 @compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/endomorphism/map.wgsl
+++ b/wonnx/templates/endomorphism/map.wgsl
@@ -3,7 +3,7 @@
 var<storage, read> input_0: ArrayVector;
 
 @group(0) @binding(1)
-var<storage, write> output_0: ArrayVector;
+var<storage, read_write> output_0: ArrayVector;
 
 @compute @workgroup_size({{ workgroup_size_x }})
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/endomorphism/onehot.wgsl
+++ b/wonnx/templates/endomorphism/onehot.wgsl
@@ -18,7 +18,7 @@ var<storage, read> input_depth: Depth;
 var<storage, read> input_values: Array;
 
 @group(0) @binding(3)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size(1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/endomorphism/softmax.wgsl
+++ b/wonnx/templates/endomorphism/softmax.wgsl
@@ -4,7 +4,7 @@
 var<storage, read> input_0: Array;
 
 @group(0) @binding(1)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/matrix/concat.wgsl
+++ b/wonnx/templates/matrix/concat.wgsl
@@ -10,7 +10,7 @@ var<storage, read> input_{{ loop.index0 }}: Array;
 
 {% set binding_len = i_lens | length %}
 @group({{ binding_len  / 4 | int }}) @binding({{ binding_len % 4 }})
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size(256, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/matrix/gemm.wgsl
+++ b/wonnx/templates/matrix/gemm.wgsl
@@ -17,10 +17,10 @@ var<storage, read> input_right: GemmArrayVector;
 	var<storage, read> input_bias: GemmArrayVector;
 
 	@group(0) @binding(3)
-	var<storage, write> output_0: GemmArrayVector;
+	var<storage, read_write> output_0: GemmArrayVector;
 {% else %}
 	@group(0) @binding(2)
-	var<storage, write> output_0: GemmArrayVector;
+	var<storage, read_write> output_0: GemmArrayVector;
 {% endif %}
 
 @compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})

--- a/wonnx/templates/matrix/gemm_1.wgsl
+++ b/wonnx/templates/matrix/gemm_1.wgsl
@@ -12,12 +12,12 @@ var<storage, read> input_1: Array;
 	var<storage, read> input_2: Array;
 
 	@group(0) @binding(3)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- else -%}
 
 	@group(0) @binding(2)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- endif -%}  
 

--- a/wonnx/templates/matrix/pad.wgsl
+++ b/wonnx/templates/matrix/pad.wgsl
@@ -5,7 +5,7 @@
 var<storage, read> input_0: Array;
 
 @group(0) @binding(1)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size(256, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/matrix/resize.wgsl
+++ b/wonnx/templates/matrix/resize.wgsl
@@ -5,7 +5,7 @@
 var<storage, read> input_0: Array;
 
 @group(0) @binding(1)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size(256, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/matrix/split.wgsl
+++ b/wonnx/templates/matrix/split.wgsl
@@ -6,7 +6,7 @@ var<storage, read> input_0: Array;
 
 {% for output in o_lens %}
 	@group({{ loop.index / 4 | int }}) @binding({{ loop.index % 4}})
-	var<storage, write> output_{{ loop.index0 }}: Array;
+	var<storage, read_write> output_{{ loop.index0 }}: Array;
 {% endfor %}
 
 @compute @workgroup_size(256, 1, 1)

--- a/wonnx/templates/matrix/transpose.wgsl
+++ b/wonnx/templates/matrix/transpose.wgsl
@@ -4,7 +4,7 @@
 var<storage, read> input_0: Array;
 
 @group(0) @binding(1)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size(256, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/pool/aggregate.wgsl
+++ b/wonnx/templates/pool/aggregate.wgsl
@@ -11,7 +11,7 @@
 var<storage, read> input_0: Array;
 
 @group(0) @binding(1)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size(256, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/wonnx/templates/pool/conv.wgsl
+++ b/wonnx/templates/pool/conv.wgsl
@@ -11,11 +11,11 @@ var<storage, read> input_1: Array;
 	var<storage, read> input_2: Array;
 
 	@group(0) @binding(3)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- else -%}
 	@group(0) @binding(2)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- endif %}
 

--- a/wonnx/templates/pool/conv_kernel_1.wgsl
+++ b/wonnx/templates/pool/conv_kernel_1.wgsl
@@ -11,11 +11,11 @@ var<storage, read> input_1: ArrayMatrix;
 	var<storage, read> input_2: ArrayVector;
 
 	@group(0) @binding(3)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- else -%}
 	@group(0) @binding(2)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- endif %}
 

--- a/wonnx/templates/pool/conv_kernel_3.wgsl
+++ b/wonnx/templates/pool/conv_kernel_3.wgsl
@@ -11,11 +11,11 @@ var<storage, read> input_1: ArrayMatrix3;
 	var<storage, read> input_2: ArrayVector;
 
 	@group(0) @binding(3)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- else -%}
 	@group(0) @binding(2)
-	var<storage, write> output_0: Array;
+	var<storage, read_write> output_0: Array;
 
 {%- endif %}
 

--- a/wonnx/templates/pool/reduce.wgsl
+++ b/wonnx/templates/pool/reduce.wgsl
@@ -4,7 +4,7 @@
 var<storage, read> input_0: Array;
 
 @group(0) @binding(1)
-var<storage, write> output_0: Array;
+var<storage, read_write> output_0: Array;
 
 @compute @workgroup_size({{ workgroup_size_x }}, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {


### PR DESCRIPTION
This replaces `var<storage, write>` in shader code with `var<storage, read_write>`. This is required because `write` is not supported (anymore?) for variables in the `storage` address space, but `read_write` is. In particular the Google Chrome (Tint) compiler complains about this. For more information see https://www.w3.org/TR/WGSL/#address-space.

This PR makes the Squeeze WebAssembly demo work again. See https://pixelspark.nl/wp-content/public/squeeze/