### PR TITLE
docs: add docs.rs badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <center><img src="logo.svg" alt="WONNX" width="700"/></center>
 
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/webonnx/wonnx/CI)
+[![docs.rs](https://img.shields.io/docsrs/wonnx)](https://docs.rs/wonnx)
 ![Crates.io (latest)](https://img.shields.io/crates/dv/wonnx)
 ![Crates.io](https://img.shields.io/crates/l/wonnx)
 


### PR DESCRIPTION
When looking at a crate's README, I usually look for the docs.rs badge at the top, and assume that it doesn't have docs otherwise. I thought that was initially the case with wonnx, but then I noticed the link to the docs later in the readme. Figured I'd add the badge to stop others from making the same assumption I did 👌 