### PR TITLE
remove incorrect lifetime annotation

### DIFF
--- a/wonnx/src/ir.rs
+++ b/wonnx/src/ir.rs
@@ -123,7 +123,7 @@ impl<'model> Node<'model> {
         let inputs: Result<Vec<Input<'model>>, IrError> = node
             .get_input()
             .iter()
-            .map(|input_name: &'model String| {
+            .map(|input_name: &String| {
                 let my_input_name = input_name.clone();
                 let source_node_definition = node_definitions_by_output
                     .get(&my_input_name)


### PR DESCRIPTION
Hi,
rustc was previously accepting this incorrect code:
```rust
async fn test<'a>() { // `'a`, being a lifetime parameter, must be longer than the entire function body
    let f = |_: &'a str| {}; // the argument is required to outlive `'a`
    f(&String::new()); // an argument of shorter lifetime is passed!
}
```
This got fixed in the current beta 1.64, but [we found that wonnx relies on this bug](https://github.com/rust-lang/rust/issues/100544). This PR tries to fix this.