### PR TITLE
Implement `Shape` operator

### DIFF
--- a/wonnx/templates/matrix/shape.wgsl
+++ b/wonnx/templates/matrix/shape.wgsl
@@ -1,0 +1,28 @@
+{%- include "structs.wgsl" -%}
+
+
+struct ArrayVector {
+	data: array<Vec4>
+};
+
+
+@group(0) @binding(0)
+var<storage, read> input_0: ArrayVector;
+
+struct OutputArray {
+    data: array<i32>
+}
+
+@group(0) @binding(1)
+var<storage, read_write> output_0: OutputArray;
+
+
+@compute @workgroup_size(256, 1, 1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+	let gidx = global_id.x;
+    let xxxx = input_0.data[0];
+     {% for idx in idxs %}
+         output_0.data[{{ loop.index0 }}] = {{ i_shape[0][idx] }};
+     {% endfor %}
+
+}

--- a/wonnx/templates/matrix/shape.wgsl
+++ b/wonnx/templates/matrix/shape.wgsl
@@ -1,11 +1,6 @@
 {%- include "structs.wgsl" -%}
 
 
-struct ArrayVector {
-	data: array<Vec4>
-};
-
-
 @group(0) @binding(0)
 var<storage, read> input_0: ArrayVector;
 
@@ -19,8 +14,8 @@ var<storage, read_write> output_0: OutputArray;
 
 @compute @workgroup_size(256, 1, 1)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-	let gidx = global_id.x;
-    let xxxx = input_0.data[0];
+    let gidx = global_id.x;
+    _ = input_0.data[0];
      {% for idx in idxs %}
          output_0.data[{{ loop.index0 }}] = {{ i_shape[0][idx] }};
      {% endfor %}


### PR DESCRIPTION
Hello!
I gave `Shape` operator a try. I pretty much got it working, however there are some small issues:

1. tests (run with `env OP_TESTED=shape pytest tests/test_specific_op.py`) almost pass, but they fail because of different types: it expects `int64` while our output is `float32`. Not sure how to fix that (output array is `i32` and I even tried setting `scalar_type` to `I64`, but this doesn't help)
2. shader is actually const, since everything is determined at shader compile time (at template render to be precise). this might be an issue (e.g. for models with dynamic inference size). but I don't know how this could be solved.
3. minor thing: because of the point above, we don't actually use `input_0` in the shader code. but if we don't use it, then it gets removed and then bindings don't check out. I solved this by binding it to unused variable, but there could be a prettier way.

P.S. I'll cleanup the code once the other issues are solved ;]