### PR TITLE
Remove `profile.release` entry from wonnx-wasm

### DIFF
--- a/wonnx-wasm/Cargo.toml
+++ b/wonnx-wasm/Cargo.toml
@@ -21,9 +21,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib"]
 
-[profile.release]
-lto = true
-
 [dependencies]
 wonnx = { version = "0.3.0" }
 log = "0.4.17"


### PR DESCRIPTION
This is ignored, since the package is part of a containing workspace, and it makes Cargo print a warning every time you do something, so it's better to remove it.