### PR TITLE
Publish `wonnx` on tag release

### DIFF
--- a/.github/workflows/create-py-mac.yaml
+++ b/.github/workflows/create-py-mac.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest"]
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Install latest Rust nightly

--- a/.github/workflows/create-py-mac.yaml
+++ b/.github/workflows/create-py-mac.yaml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "wonnx-py-v*" # Push events to matching wonnx-py-v*
+      - "v*" # Push events to matching wonnx-py-v*
 
 jobs:
   build:

--- a/.github/workflows/create-py-manylinux.yaml
+++ b/.github/workflows/create-py-manylinux.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/create-py-manylinux.yaml
+++ b/.github/workflows/create-py-manylinux.yaml
@@ -9,8 +9,15 @@ jobs:
   build_manylinux:
     name: Create Release manylinux
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Publish wheel
         uses: docker://konstin2/maturin:latest
         env:

--- a/.github/workflows/create-py-manylinux.yaml
+++ b/.github/workflows/create-py-manylinux.yaml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "wonnx-py-v*" # Push events to matching wonnx-py-v*
+      - "v*" # Push events to matching wonnx-py-v*
 jobs:
   build_manylinux:
     name: Create Release manylinux

--- a/.github/workflows/create-py-windows.yaml
+++ b/.github/workflows/create-py-windows.yaml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "wonnx-py-v*" # Push events to matching wonnx-py-v*
+      - "v*" # Push events to matching wonnx-py-v*
 jobs:
   build:
     name: Create Release

--- a/.github/workflows/create-py-windows.yaml
+++ b/.github/workflows/create-py-windows.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "windows-latest"]
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Install latest Rust nightly

--- a/wonnx-py/Cargo.toml
+++ b/wonnx-py/Cargo.toml
@@ -2,7 +2,10 @@
 name = "wonnx-py"
 version = "0.3.0"
 edition = "2018"
-authors = ["haixuanTao <tao.xavier@outlook.com>", "Tommy van der Vorst <tommy@pixelspark.nl>"]
+authors = [
+    "haixuanTao <tao.xavier@outlook.com>",
+    "Tommy van der Vorst <tommy@pixelspark.nl>",
+]
 license = "MIT OR Apache-2.0"
 description = "Wonnx is an ONNX runtime based on wgpu aimed at being a universal GPU runtime, written in Rust."
 repository = "https://github.com/webonnx/wonnx.git"
@@ -13,7 +16,7 @@ homepage = "https://github.com/webonnx/wonnx"
 [dependencies]
 wonnx = { version = "0.3.0" }
 protobuf = { version = "2.27.1", features = ["with-bytes"] }
-pyo3 = "0.16.5"
+pyo3 = { version = "0.16.5", features = ["abi3-py37"] }
 pollster = "0.2.5"
 env_logger = "0.9.0"
 

--- a/wonnx-py/pyproject.toml
+++ b/wonnx-py/pyproject.toml
@@ -5,9 +5,9 @@ build-backend = "maturin"
 [project]
 name = "wonnx"
 dependencies = [
-  # "typing_extensions >= 4.0.0; python_version < '3.10'",
+    # "typing_extensions >= 4.0.0; python_version < '3.10'",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 
 [tool.isort]
 profile = "black"
@@ -17,4 +17,3 @@ disallow_untyped_defs = true
 warn_unused_ignores = true
 show_error_codes = true
 files = ["tests"]
-


### PR DESCRIPTION
This pull request change the CD logic to publish on tag release to make it in sync with the rust publishing version