### PR TITLE
Improve `CompileError` message with unnamed nodes

### DIFF
--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -510,7 +510,11 @@ impl<'model> OperatorDefinition<'model> {
         let CompiledNode { shader, threads } =
             compile(proto, &input_shapes, &output_shapes, opset_version).map_err(|ce| {
                 GpuError::CompileError {
-                    node: proto.get_name().to_string(),
+                    node: if proto.has_name() {
+                        proto.get_name().to_string()
+                    } else {
+                        proto.get_op_type().to_string()
+                    },
                     error: ce,
                 }
             })?;


### PR DESCRIPTION
This way, the node type is mentioned if the node has no name, which can often pinpoint the specific node regardless