### PR TITLE
fix: replace 'type' with 'alias' in WGSL

### DIFF
--- a/wonnx/templates/matrix/gemm.wgsl
+++ b/wonnx/templates/matrix/gemm.wgsl
@@ -1,6 +1,6 @@
-type Scalar = {{ scalar_type }};
-type GemmVec = vec{{ kernel_size }}<{{ scalar_type }}>;
-type GemmMat = mat{{ kernel_size }}x{{ kernel_size }}<{{ scalar_type }}>;
+alias Scalar = {{ scalar_type }};
+alias GemmVec = vec{{ kernel_size }}<{{ scalar_type }}>;
+alias GemmMat = mat{{ kernel_size }}x{{ kernel_size }}<{{ scalar_type }}>;
 
 struct GemmArrayVector {
 	data: array<GemmVec>

--- a/wonnx/templates/structs.wgsl
+++ b/wonnx/templates/structs.wgsl
@@ -2,9 +2,9 @@
 // Operations usually work with a single scalar data type (typically f32). This data type is set by the compiler as the
 // 'scalar_type' variable. Here we define several other useful data types that shader code can use to make it more portable.
 #}
-type Scalar = {{ scalar_type }};
-type Vec3 = vec3<{{ scalar_type }}>;
-type Vec4 = vec4<{{ scalar_type }}>;
+alias Scalar = {{ scalar_type }};
+alias Vec3 = vec3<{{ scalar_type }}>;
+alias Vec4 = vec4<{{ scalar_type }}>;
 
 struct Array {
 	data: array<Scalar>
@@ -18,9 +18,9 @@ struct ArrayVector {
 // WGSL only supports matrixes for floating point types at this point 
 #}
 {% if scalar_type_is_float %}
-	type Mat3x3 = mat3x3<{{ scalar_type }}>;
-	type Mat4x4 = mat4x4<{{ scalar_type }}>;
-	type Mat4x3 = mat4x3<{{ scalar_type }}>;
+	alias Mat3x3 = mat3x3<{{ scalar_type }}>;
+	alias Mat4x4 = mat4x4<{{ scalar_type }}>;
+	alias Mat4x3 = mat4x3<{{ scalar_type }}>;
 
 	struct ArrayMatrix {
 		data: array<Mat4x4>


### PR DESCRIPTION
Fixes the following warning in Chrome:

![image](https://user-images.githubusercontent.com/181337/219947740-346d9319-1551-4737-9a36-e566b803d0fd.png)

Cannot merge right now, because we are still pinned on wgpu 0.14 (see #140). Applying this now removes the warning in Chrome but makes the native version fail, because wgpu's own wgsl compiler does not yet know about 'alias'.