### PR TITLE
perf: re-use intermediate value buffers

### DIFF
--- a/wonnx-cli/src/cpu.rs
+++ b/wonnx-cli/src/cpu.rs
@@ -101,7 +101,7 @@ impl Inferer for CPUInferer {
         }
 
         let result = self.model.run(cpu_inputs_ordered)?;
-        log::info!("cpu result: {:?}", result);
+        log::debug!("cpu result: {:?}", result);
 
         let mut output_tensors = HashMap::<String, OutputTensor>::new();
 
@@ -115,7 +115,7 @@ impl Inferer for CPUInferer {
                     .enumerate()
                     .find(|x| &self.model.model.outlet_labels[x.1] == output_name)
                 {
-                    log::info!(
+                    log::debug!(
                         "output node with name '{}' has idx {:?} (and tract id {}, slot {}, name '{}')",
                         output_name,
                         idx.0,

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -331,7 +331,7 @@ pub fn compile(
                 .collect();
             let chunks_with_dims_preserved = Shape::from(scalar_type, &dims_removed).chunks();
 
-            log::info!(
+            log::debug!(
                 "reduce Op={} axes={:?} output_shape={:?} chunks_with_dims_preserved={:?} output_length={}",
                 op,
                 axes,
@@ -501,15 +501,6 @@ pub fn compile(
             let right_of_axis_chunk = input_shapes[0].dims[((axis + 1) as usize)..]
                 .iter()
                 .product::<u64>();
-            log::info!(
-                "axis={}, left_of_axis={:?} slice={:?} axis_chunk={:?} slice={:?} right_of_axis_chunk={:?}",
-                axis,
-                left_of_axis,
-                &input_shapes[0].dims[0..(axis as usize)],
-                axis_chunk,
-                &input_shapes[0].dims[(axis as usize)..],
-                right_of_axis_chunk
-            );
 
             context.insert("axis_chunk", &axis_chunk);
 
@@ -1424,7 +1415,7 @@ fn workgroup_size(
     Ok(if x > max_x {
         let workgroup_size = ceil(x, max_x) as _;
         let threads = ceil(x, workgroup_size as u64) as _;
-        log::info!(
+        log::debug!(
             "number of items ({}) exceeds maximum number of threads ({}); adjusting workgroup size={} and threads={} (this will compute {} items)",
             x,
             max_x,

--- a/wonnx/src/gpu.rs
+++ b/wonnx/src/gpu.rs
@@ -865,24 +865,6 @@ impl<'model> OperatorDefinition<'model> {
             binding_counter += 1;
         }
 
-        // Check if we are not using the same buffer on both the input and output side (this verifies the correct behaviour
-        // of the shared intermediate buffer manager)
-        #[cfg(debug_assertions)]
-        {
-            let all_input_buffers: Vec<*const Buffer> = input_tensors
-                .iter()
-                .map(|x| Arc::as_ptr(&x.buffer))
-                .collect();
-            for out_tensor in &output_tensors {
-                if all_input_buffers.contains(&Arc::as_ptr(&out_tensor.buffer)) {
-                    panic!(
-                        "output is also an input at node with outputs {:#?}",
-                        self.proto.get_output()
-                    );
-                }
-            }
-        }
-
         // Set up a pipeline (basically the shader source code with some metadata that determines how it will be executed)
         let mut bind_groups = vec![];
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {

--- a/wonnx/src/ir.rs
+++ b/wonnx/src/ir.rs
@@ -234,7 +234,7 @@ impl<'model> Node<'model> {
                 node_definitions_by_output
                     .insert(input.get_name().to_string(), NodeDefinition::Input(input));
             } else {
-                log::info!(
+                log::debug!(
                     "Skipping input definition {}: already defined",
                     input.get_name()
                 );

--- a/wonnx/src/ir.rs
+++ b/wonnx/src/ir.rs
@@ -210,7 +210,6 @@ impl<'model> Node<'model> {
 
         // Collect intializer info
         for initializer in model.get_graph().get_initializer().iter() {
-            log::debug!("Initializer {}", initializer.get_name());
             node_definitions_by_output.insert(
                 initializer.get_name().to_string(),
                 NodeDefinition::Tensor(Box::new(Cow::Borrowed(initializer))),
@@ -230,7 +229,6 @@ impl<'model> Node<'model> {
         // Collect input name
         for input in model.get_graph().get_input().iter() {
             if !node_definitions_by_output.contains_key(input.get_name()) {
-                log::debug!("Input {}", input.get_name());
                 node_definitions_by_output
                     .insert(input.get_name().to_string(), NodeDefinition::Input(input));
             } else {
@@ -304,6 +302,15 @@ impl<'model> Debug for NodeDefinition<'model> {
 /// Wrap an Arc<Node> in a struct so we can implement pointer-based comparison for it, and use them as keys in a HashSet/HashMap
 #[derive(Clone)]
 pub struct NodeIdentifier<'model>(Arc<Node<'model>>);
+
+impl<'model> Debug for NodeIdentifier<'model> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("NodeIdentifier")
+            .field(&Arc::as_ptr(&self.0))
+            .field(&self.0.definition.get_name())
+            .finish()
+    }
+}
 
 impl<'model> Hash for NodeIdentifier<'model> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
This PR enabled re-usage of buffers for intermediate values (see #47) using a graph coloring algoritm. Basically, during the 'pre sequence' phase, a buffer manager keeps track of shared buffers and hands them out for use as intermediate value buffer, while keeping track of the lifetimes of each buffer. 

For the included MNIST example (which is basically a linear graph of 8 nodes, optimized down to 6 nodes), we'd previously allocate 6 buffers for intermediate values. With this PR, only 2 are allocated (leading to a reduction of 1.46x in total buffer size). For the Squeeze example, the difference is more dramatic (only 3 buffers needed, 3.19x improvement in size). This is due to the fact that Squeeze too is relatively linear, but with multiple similar blocks of nodes repeated.

Note, this PR should pass all tests but it currently fails with a BERT model:

````
2023-02-26T17:13:46Z ERROR wgpu::backend::direct] Handling wgpu errors as fatal by default
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In a ComputePass
      note: encoder = `<CommandBuffer-(0, 2, Metal)>`
    In a dispatch command, indirect:false
      note: compute pipeline = `bert/embeddings/add`
    Attempted to use buffer with conflicting usages. Current usage STORAGE_READ and new usage STORAGE_READ_WRITE. STORAGE_READ_WRITE is an exclusive usage and cannot be used with any otherusages within the usage scope (renderpass or compute dispatch).
````

Will look into this later.