### PR TITLE
Fix `Clip` node implementation

### DIFF
--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -747,6 +747,27 @@ pub fn compile(
             };
             context.insert("alpha", &alpha);
 
+            if op == "Clip" {
+                let min: Vec<f32> = node.get_attribute_value("min", None)?;
+                let max: Vec<f32> = node.get_attribute_value("max", None)?;
+                if min.len() != 1 {
+                    return Err(CompileError::InvalidAttributeValue {
+                        attribute: "min".into(),
+                        value: format!("{min:?}"),
+                        opset_version,
+                    });
+                }
+                if max.len() != 1 {
+                    return Err(CompileError::InvalidAttributeValue {
+                        attribute: "max".into(),
+                        value: format!("{max:?}"),
+                        opset_version,
+                    });
+                }
+                context.insert("min", &format!("{:.1}", min[0]));
+                context.insert("max", &format!("{:.1}", max[0]));
+            }
+
             let (x_threads, workgroup_size_x) = workgroup_size(
                 ceil(output_lengths[0], 4),
                 MAX_COMPUTE_WORKGROUPS_PER_DIMENSION,

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -748,8 +748,9 @@ pub fn compile(
             context.insert("alpha", &alpha);
 
             if op == "Clip" {
-                let min: Vec<f32> = node.get_attribute_value("min", None)?;
-                let max: Vec<f32> = node.get_attribute_value("max", None)?;
+                let min: Vec<f32> =
+                    node.get_attribute_value("min", Some(vec![f32::NEG_INFINITY]))?;
+                let max: Vec<f32> = node.get_attribute_value("max", Some(vec![f32::INFINITY]))?;
                 if min.len() != 1 {
                     return Err(CompileError::InvalidAttributeValue {
                         attribute: "min".into(),

--- a/wonnx/templates/snippets/activation_scalar.wgsl
+++ b/wonnx/templates/snippets/activation_scalar.wgsl
@@ -12,13 +12,10 @@
 	{{ activation_output }} = log({{ scalar_type }}(1) + exp({{ activation_input }}));
 
 {%- elif activation_type == "Clip" -%}
-	let min_clip = input_1.data[0u];
-	let max_clip = input_2.data[0u];
-
 	{{ activation_output }} = clamp(
 		{{ activation_input }}, 
-		Vec4(min_clip, min_clip, min_clip, min_clip),
-		Vec4(max_clip, max_clip, max_clip, max_clip),
+		{{ min }},
+		{{ max }},
 	);
 
 {%- elif activation_type == "Celu" -%}

--- a/wonnx/templates/snippets/activation_vec.wgsl
+++ b/wonnx/templates/snippets/activation_vec.wgsl
@@ -12,12 +12,10 @@
 	{{ activation_output }} = log(Vec4({{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1), {{ scalar_type }}(1)) + exp({{ activation_input }}));
 
 {%- elif activation_type == "Clip" -%}
-	let min_clip = input_1.data[0u];
-	let max_clip = input_2.data[0u];
 	{{ activation_output }} = clamp(
-		{{ activation_input }}, 
-		Vec4(min_clip, min_clip, min_clip, min_clip),
-		Vec4(max_clip, max_clip, max_clip, max_clip),
+		{{ activation_input }},
+		Vec4({{ min }}, {{ min }}, {{ min }}, {{ min }}),
+		Vec4({{ max }}, {{ max }}, {{ max }}, {{ max }}),
 	);
 
 {%- elif activation_type == "Celu" -%}


### PR DESCRIPTION
This changes the input->attribute conversion to work with any element type, and passes the min and max attributes to the shader (which was expecting input buffers for some reason).

The upstream tests for this use dynamic min/max inputs and won't work with wonnx, so I've added a custom Rust test.