### PR TITLE
Respect `raw_data` when promoting initializer

### DIFF
--- a/wonnx/Cargo.toml
+++ b/wonnx/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 
 [dependencies]
 wgpu = "0.14.0"
-bytemuck = "1.9.1"
+bytemuck = { version = "1.9.1", features = ["extern_crate_alloc"] }
 protobuf = { version = "2.27.1", features = ["with-bytes"] }
 log = "0.4.17"
 tera = { version = "1.15.0", default-features = false }

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -164,7 +164,7 @@ pub enum CompileError {
     #[error("the opset version {0} is not supported")]
     UnsupportedOpsetVersion(i64),
 
-    #[error("the value '{attribute}' is invalid for attribute '{value}' (opset version {opset_version})")]
+    #[error("the value '{value}' is invalid for attribute '{attribute}' (opset version {opset_version})")]
     InvalidAttributeValue {
         attribute: String,
         value: String,


### PR DESCRIPTION
Fixes https://github.com/webonnx/wonnx/issues/159

A better way to avoid issues like this would be to use a proper IR instead of the raw protobuf types, but that's a pretty major refactoring.

I didn't include a test here since the ONNX file in question is pretty large and still doesn't work because of other missing features.