### PR TITLE
feat: Add support for slice operator

### DIFF
--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -447,8 +447,31 @@ pub fn compile(
 
         "Slice" => {
             // TODO @ Raphael
+            // Goal: Implementing slice in version 11:
+            // https://onnx.ai/onnx/operators/onnx__Slice.html#slice-11
+            // 1. Get attributes out of node.
+            // 2. Create input and output buffer.
+            // 3. Provide attributes to compute shader.
+            // 4. Call compute shader over output.
+            // 5. Fill output in compute shader.
 
-            // Copied from Gather.
+            println!("Slice by Raphael");
+            println!("op_type: {:?}", &node.get_op_type());
+            println!("opset_version: {:?}", &opset_version);
+
+            // Get attributes from node.
+            let starts = node.get_attribute_value("starts", Some(vec![0]))?;
+            let ends = node.get_attribute_value("ends", Some(vec![0]))?;
+            let axes = node.get_attribute_value("axes", Some(vec![0]))?;
+            let steps = node.get_attribute_value("steps", Some(vec![1]))?;
+
+            // Print attributes.
+            println!("starts: {:?}", &starts);
+            println!("ends: {:?}", &ends);
+            println!("axes: {:?}", &axes);
+            println!("steps: {:?}", &steps);
+
+            // Copied from Gather to avoid compilation error.
             // Input 0 is data, input 1 is indices
             // Which axis to gather on. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).
             // Default is 0. See https://github.com/onnx/onnx/blob/main/docs/Operators.md#attributes-25
@@ -484,12 +507,12 @@ pub fn compile(
             context.insert("workgroup_size_x", &workgroup_size_x);
             context.insert("workgroup_size_y", &workgroup_size_y);
 
-
             NodeTemplate {
                 scalar_type,
                 template: "endomorphism/slice.wgsl",
                 threads: (x_threads, y_threads, 1),
             }
+            // Above to be removed / replaced.
         }
 
         "Cast" => {

--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -135,6 +135,11 @@ lazy_static! {
             include_str!("../templates/endomorphism/broadcast.wgsl"),
         )
         .unwrap();
+        tera.add_raw_template(
+            "endomorphism/slice.wgsl",
+            include_str!("../templates/endomorphism/slice.wgsl"),
+        )
+        .unwrap();
         tera
     };
 }
@@ -436,6 +441,53 @@ pub fn compile(
             NodeTemplate {
                 scalar_type,
                 template: "endomorphism/gather.wgsl",
+                threads: (x_threads, y_threads, 1),
+            }
+        }
+
+        "Slice" => {
+            // TODO @ Raphael
+
+            // Copied from Gather.
+            // Input 0 is data, input 1 is indices
+            // Which axis to gather on. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).
+            // Default is 0. See https://github.com/onnx/onnx/blob/main/docs/Operators.md#attributes-25
+            let axis = node.get_attribute_value("axis", Some(0))?;
+            if axis != 0 {
+                return Err(CompileError::UnimplementedVariant {
+                    variant: format!("axis={}", axis),
+                    op: String::from("Gather"),
+                });
+            }
+
+            let elements_per_index = input_chunks[0][0];
+            let scalar_type = agreed_type(&input_shapes[0..1], output_shapes)?;
+            let chunk_type = MultiType::for_size(elements_per_index as usize, scalar_type);
+            let chunk_size = chunk_type.elements();
+
+            // The X dimension represents the indexes
+            let (x_threads, workgroup_size_x) = workgroup_size(
+                input_lengths[1],
+                MAX_COMPUTE_WORKGROUPS_PER_DIMENSION,
+                MAX_WORKGROUP_SIZE_X,
+            )?;
+
+            // The Y dimension represents the elements to copy for each index
+            let (y_threads, workgroup_size_y) = workgroup_size(
+                ceil(elements_per_index, chunk_size as u64),
+                MAX_COMPUTE_WORKGROUPS_PER_DIMENSION,
+                MAX_WORKGROUP_SIZE_Y,
+            )?;
+
+            context.insert("chunk_type", &chunk_type.wgsl_type_name());
+            context.insert("chunk_size", &chunk_size);
+            context.insert("workgroup_size_x", &workgroup_size_x);
+            context.insert("workgroup_size_y", &workgroup_size_y);
+
+
+            NodeTemplate {
+                scalar_type,
+                template: "endomorphism/slice.wgsl",
                 threads: (x_threads, y_threads, 1),
             }
         }

--- a/wonnx/templates/endomorphism/slice.wgsl
+++ b/wonnx/templates/endomorphism/slice.wgsl
@@ -1,0 +1,23 @@
+{%- include "structs.wgsl" -%}
+
+struct Indices {
+	data: array<i32>
+};
+
+struct Chunk {
+	data: array<{{ chunk_type }}>
+};
+
+@group(0) @binding(0)
+var<storage, read> input_0: Chunk; // data
+
+@group(0) @binding(1)
+var<storage, read> input_1: Indices; // indices
+
+@group(0) @binding(2)
+var<storage, read_write> output_0: Chunk;
+
+@compute @workgroup_size({{ workgroup_size_x }}, {{ workgroup_size_y }})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+	// TODO @ Raphael
+}


### PR DESCRIPTION
Hello 👋!

I need  the slice operator (v11) to infer one of our models. I have seen in issue #153 that the slice operator is not yet implemented in `wonnx`, thus I plan to tackle the task. I have low experience in Rust, yet high in C++, and medium experience in Compute Shaders, mostly OpenGL 4. Therefore, I would suggest to treat this PR as basis to support me in understanding how to approach this venture. I have read the instructions from your README and attempted to get into the code of the project.

I already fail at extracting the attribute values from a slice node of our model. It looks like all attributes according to the ONNX specification [1] are integer vectors. I have spotted in https://github.com/webonnx/wonnx/blob/c772653fe97c0e9b523cdf530a71bff66ec51176/wonnx/src/compiler.rs#L821 how you extract such an attribute. However, when I apply the same scheme as seen in line lines 463-466 of `compiler.rs` it just returns the default values I defined. What am I missing?

I hope you are fine with my approach to this pull request. Otherwise I can also provide specific issues if desired.

Cheers,
Raphael

[1] https://onnx.ai/onnx/operators/onnx__Slice.html#slice-11