### PR TITLE
WIP: Implement `Pad` `mode=reflect`

### DIFF
--- a/wonnx/src/compiler.rs
+++ b/wonnx/src/compiler.rs
@@ -1308,6 +1308,7 @@ pub fn compile(
             let mode = node.get_attribute_value("mode", Some("constant".to_string()))?;
             match mode.as_str() {
                 "constant" => {}
+                "reflect" => {}
                 _ => {
                     return Err(CompileError::UnimplementedVariant {
                         op: String::from("Pad"),
@@ -1315,6 +1316,7 @@ pub fn compile(
                     })
                 }
             }
+            context.insert("mode", &mode);
 
             let pads: Vec<i64> = node.get_attribute_value("pads", None)?;
             if pads.len() != input_shapes[0].rank() * 2 {


### PR DESCRIPTION
WIP, following the general outline from [here](https://github.com/webonnx/wonnx/pull/106#issuecomment-1652718272) to implement reflect mode.

I have just about zero experience with compute shaders or WGPU, so some help in actually implementing the reflect mode in the shader would be much appreciated.