### PR TITLE
Fix Concat for larger inputs and add an additional test

### DIFF
--- a/wonnx/templates/matrix/concat.wgsl
+++ b/wonnx/templates/matrix/concat.wgsl
@@ -17,9 +17,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(num_workgr
 	let gidx = global_id.x;
         let gidy = global_id.y;
 
-        let nx = num_workgroups.x;
+        let x_executions = num_workgroups.x * 16u;
 
-        let actual_idx = gidx + gidy * nx;
+        let actual_idx = gidx + gidy * x_executions;
 	
 	{% for input in i_lens %}
 		{% if loop.first %}


### PR DESCRIPTION
I messed this up in !180, sorry about that.
The `num_workgroups` obviously only contains the number of workgroup invocations along each axis.
To calculate `actual_idx`, we need to consider the total number of executions in the x axis, so we have to multiply with the workgroup size.