### PR TITLE
Remove `lazy_static` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,7 +4202,6 @@ dependencies = [
  "env_logger",
  "futures",
  "image",
- "lazy_static",
  "log",
  "ndarray",
  "num",

--- a/wonnx/Cargo.toml
+++ b/wonnx/Cargo.toml
@@ -27,7 +27,6 @@ bytemuck = { version = "1.9.1", features = ["extern_crate_alloc"] }
 protobuf = { version = "2.27.1", features = ["with-bytes"] }
 log = "0.4.17"
 tera = { version = "1.15.0", default-features = false }
-lazy_static = "1.4.0"
 thiserror = "1.0.31"
 serde_derive = "1.0.137"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/wonnx/src/lib.rs
+++ b/wonnx/src/lib.rs
@@ -6,9 +6,6 @@ mod optimizer;
 mod resource;
 pub mod utils;
 
-#[macro_use]
-extern crate lazy_static;
-
 pub use compiler::CompileError;
 pub use gpu::GpuError;
 use ir::IrError;


### PR DESCRIPTION
`OnceLock` can be used to achieve the same thing without pulling in a dependency. Requires Rust 1.70.0.