### PR TITLE
set async_recursion to ?Send for wasm32 arch

### DIFF
--- a/wonnx/src/optimizer.rs
+++ b/wonnx/src/optimizer.rs
@@ -292,7 +292,8 @@ impl<'model> Optimizer<'model> {
     }
 
     /// Optimize a branch of a graph (memoized)
-    #[async_recursion]
+    #[cfg_attr(target_arch = "wasm32", async_recursion(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_recursion)]
     pub async fn optimize(
         &mut self,
         node: Arc<Node<'model>>,
@@ -310,7 +311,8 @@ impl<'model> Optimizer<'model> {
 
     /// Optimize a branch of a graph. Takes a node an attempts to form a chain of nodes with single (dynamic) inputs by
     /// traversing towards the inputs.
-    #[async_recursion]
+    #[cfg_attr(target_arch = "wasm32", async_recursion(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_recursion)]
     async fn optimize_actual(
         &mut self,
         node: Arc<Node<'model>>,


### PR DESCRIPTION
In the dependency upgrade for wgpu from 16 -> 19, wbgpu started properly labeling their structs as non send/sync which broke the expectations for the async_recursion proc macro. By configuring the macro to not expect a type that is Send, the wasm build of wgpu should properly compile. No callsites of the updaded function require that the type be Send, so there wasn't a need to update anything else.